### PR TITLE
Release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2025-09-02
+
+### Fixed
+- **Java License Detection Enhancement**
+  - Java extractor now scans for license files within JAR archives (e.g., META-INF/LICENSE)
+  - Previously relied only on POM metadata for license detection
+  - Improves license detection coverage for packages like Guava that include license files but don't declare them in POM
+  - Merges detected licenses with existing POM-declared licenses while avoiding duplicates
+
 ## [1.5.0] - 2025-08-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-upmex"
-version = "1.5.0"
+version = "1.5.1"
 description = "Universal Package Metadata Extractor - Extract metadata from various package formats"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/upmex/__init__.py
+++ b/src/upmex/__init__.py
@@ -1,6 +1,6 @@
 """UPMEX - Universal Package Metadata Extractor."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __author__ = "Oscar Valenzuela B."
 __email__ = "oscar.valenzuela.b@gmail.com"
 


### PR DESCRIPTION
## Summary
Version bump to 1.5.1 with changelog updates.

## Changes in v1.5.1

### Fixed
- **Java License Detection Enhancement**
  - Java extractor now scans for license files within JAR archives (e.g., META-INF/LICENSE)
  - Previously relied only on POM metadata for license detection
  - Improves license detection coverage for packages like Guava that include license files but don't declare them in POM
  - Merges detected licenses with existing POM-declared licenses while avoiding duplicates

## Files Changed
- `pyproject.toml` - Version bumped to 1.5.1
- `src/upmex/__init__.py` - Version bumped to 1.5.1
- `CHANGELOG.md` - Added v1.5.1 release notes

## Testing
The Java license detection enhancement has been tested with:
- guava-33.4.0-jre.jar - Now correctly detects Apache-2.0 license from META-INF/LICENSE
- gson-2.10.1.jar - Still correctly detects license from POM metadata