### PR TITLE
fix: add missing toml dependency for Rust crate extraction (v1.5.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.8] - 2025-09-16
+
+### Fixed
+- **Missing toml dependency** (#43)
+  - Added toml package as explicit dependency for Rust crate extraction
+  - Fixes ImportError when extracting Rust packages in fresh installations
+
 ## [1.5.7] - 2025-09-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-upmex"
-version = "1.5.7"
+version = "1.5.8"
 description = "Universal Package Metadata Extractor - Extract metadata from various package formats"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -39,6 +39,7 @@ dependencies = [
     "click>=8.0.0",
     "typing-extensions>=4.0.0;python_version<'3.10'",
     "semantic-copycat-oslili>=1.3.4",
+    "toml>=0.10.0",
 ]
 
 [project.optional-dependencies]

--- a/src/upmex/__init__.py
+++ b/src/upmex/__init__.py
@@ -1,6 +1,6 @@
 """UPMEX - Universal Package Metadata Extractor."""
 
-__version__ = "1.5.7"
+__version__ = "1.5.8"
 __author__ = "Oscar Valenzuela B."
 __email__ = "oscar.valenzuela.b@gmail.com"
 


### PR DESCRIPTION
## Summary
- Fixes #43 - Add missing toml package dependency
- Bumps version to 1.5.8
- Updates changelog with fix details

## Problem
The `toml` package was imported in `rust_extractor.py` but not declared as a dependency in `pyproject.toml`. This caused ImportError when extracting Rust packages in fresh installations.

## Solution
Added `toml>=0.10.0` to the project dependencies list to ensure it's installed with the package.

## Test plan
- [x] Verified toml import works: `python -c "from upmex.extractors.rust_extractor import RustExtractor"`
- [x] Rebuilt package with `pip install -e .`
- [x] Confirmed version update to 1.5.8
- [x] Test suite runs (some existing test failures unrelated to this change)