### PR TITLE
Release v1.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.9] - 2025-09-17
+
+### Fixed
+- **NPM extractor prioritizes root package.json** (#45)
+  - Fixed issue where NPM packages with multiple package.json files would use the wrong one
+  - Now prioritizes `package/package.json` (root) over nested package.json files
+  - Added error handling for empty or corrupt package.json files
+  - Resolves homepage field extraction issue for packages like yargs
+
 ## [1.5.8] - 2025-09-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-upmex"
-version = "1.5.8"
+version = "1.5.9"
 description = "Universal Package Metadata Extractor - Extract metadata from various package formats"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/upmex/__init__.py
+++ b/src/upmex/__init__.py
@@ -1,6 +1,6 @@
 """UPMEX - Universal Package Metadata Extractor."""
 
-__version__ = "1.5.8"
+__version__ = "1.5.9"
 __author__ = "Oscar Valenzuela B."
 __email__ = "oscar.valenzuela.b@gmail.com"
 


### PR DESCRIPTION
## Release v1.5.9

### Summary
This release fixes a critical issue with NPM package extraction where packages with multiple package.json files would use the wrong metadata file.

### Changes
- **Fixed NPM extractor to prioritize root package.json** (#45)
  - NPM packages with nested package.json files now correctly use the root package.json
  - Added robust error handling for empty or corrupt package.json files
  - Resolves homepage field extraction issue for packages like yargs

### Testing
- ✅ Tested with yargs package (previously failing case) - now extracts homepage correctly
- ✅ Tested with express package - no regression, still works correctly
- ✅ Error handling tested with empty/corrupt files

### Files Changed
- `src/upmex/extractors/npm_extractor.py` - Core fix implementation
- `pyproject.toml` - Version bump to 1.5.9
- `src/upmex/__init__.py` - Version bump to 1.5.9
- `CHANGELOG.md` - Added release notes

### Release Checklist
- [x] Version bumped in pyproject.toml
- [x] Version bumped in __init__.py
- [x] CHANGELOG.md updated
- [x] Tests pass
- [x] No regressions detected