### PR TITLE
fix(npm): record declared license when osslili cannot classify it

### DIFF
--- a/src/upmex/extractors/npm_extractor.py
+++ b/src/upmex/extractors/npm_extractor.py
@@ -4,7 +4,13 @@ import json
 from pathlib import Path
 from typing import Dict, Any
 from .base import BaseExtractor
-from ..core.models import PackageMetadata, PackageType, NO_ASSERTION
+from ..core.models import (
+    PackageMetadata,
+    PackageType,
+    LicenseInfo,
+    LicenseConfidenceLevel,
+    NO_ASSERTION,
+)
 
 
 class NpmExtractor(BaseExtractor):
@@ -161,34 +167,20 @@ class NpmExtractor(BaseExtractor):
     def _extract_license(self, metadata: PackageMetadata, data: Dict):
         """Extract license information from package.json."""
         license_data = data.get('license') or data.get('licenses')
-        
+
         if not license_data:
             return
-        
+
         if isinstance(license_data, str):
             # Simple string license
-            # Format license text for better osslili detection
-            if len(license_data) < 20 and ':' not in license_data:
-                formatted_text = f"License: {license_data}"
-            else:
-                formatted_text = license_data
-            detected = self.detect_licenses_from_text(formatted_text, 'package.json')
-            if detected:
-                metadata.licenses.extend(detected)
-                
+            self._record_declared_license(metadata, license_data)
+
         elif isinstance(license_data, dict):
             # Dict with 'type' field
             license_type = license_data.get('type')
             if license_type:
-                # Format license text for better osslili detection
-                if len(license_type) < 20 and ':' not in license_type:
-                    formatted_text = f"License: {license_type}"
-                else:
-                    formatted_text = license_type
-                detected = self.detect_licenses_from_text(formatted_text, 'package.json')
-                if detected:
-                    metadata.licenses.extend(detected)
-                    
+                self._record_declared_license(metadata, license_type)
+
         elif isinstance(license_data, list):
             # Multiple licenses
             for lic in license_data:
@@ -197,13 +189,39 @@ class NpmExtractor(BaseExtractor):
                     license_text = lic
                 elif isinstance(lic, dict):
                     license_text = lic.get('type')
-                
+
                 if license_text:
-                    # Format license text for better osslili detection
-                    if len(license_text) < 20 and ':' not in license_text:
-                        formatted_text = f"License: {license_text}"
-                    else:
-                        formatted_text = license_text
-                    detected = self.detect_licenses_from_text(formatted_text, 'package.json')
-                    if detected:
-                        metadata.licenses.extend(detected)
+                    self._record_declared_license(metadata, license_text)
+
+    def _record_declared_license(self, metadata: PackageMetadata, declared: str):
+        """Record a license declared in package.json.
+
+        The npm ``license``/``licenses`` field is an authoritative, declared
+        SPDX expression. We still run osslili text detection first so that
+        recognised licenses get osslili's richer metadata (confidence, exact
+        SPDX tag). But when osslili cannot classify the string — e.g.
+        ``"Proprietary"`` or ``"UNLICENSED"``, which are valid npm values but
+        not detectable license *text* — we fall back to recording the declared
+        value verbatim rather than dropping it.
+        """
+        # Format license text for better osslili detection.
+        if len(declared) < 20 and ':' not in declared:
+            formatted_text = f"License: {declared}"
+        else:
+            formatted_text = declared
+        detected = self.detect_licenses_from_text(formatted_text, 'package.json')
+        if detected:
+            metadata.licenses.extend(detected)
+            return
+
+        # osslili produced nothing; keep the declared value.
+        metadata.licenses.append(
+            LicenseInfo(
+                spdx_id=declared,
+                name=declared,
+                confidence=1.0,
+                confidence_level=LicenseConfidenceLevel.HIGH,
+                detection_method="declared",
+                file_path="package.json",
+            )
+        )


### PR DESCRIPTION
## Problem

`test_proprietary_license_extraction` failed on Python 3.13 (and 3.14): an npm package declaring `"license": "Proprietary"` produced an empty `licenses` list. Passed on 3.9–3.11 only because an older osslili build happened to fuzzy-match the bare word.

## Root cause

`_extract_license` routed the declared `license`/`licenses` value through osslili **text** detection and kept the result *only if osslili detected something*. But the npm `license` field is a declared SPDX expression, not license body text — osslili returns nothing for `Proprietary`, `UNLICENSED`, or a bare id, so the declared value was silently dropped.

## Fix

- Add `_record_declared_license`: run osslili detection first (recognised licenses like MIT keep their `osslili_tag` metadata and confidence), then **fall back to recording the declared value verbatim** (`detection_method="declared"`, confidence 1.0) when osslili returns nothing.
- Consolidate the three duplicated string/dict/list branches into that one helper.

## Verification

```
pytest -q   # 152 passed, 2 skipped
```
Existing MIT/Apache/BSD tests still pass with their original `osslili_tag`/`regex_*` detection methods (fallback only triggers when osslili finds nothing).