### PR TITLE
chore(release): v1.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.8] - 2026-07-24
+
+### Fixed
+- **NPM declared licenses no longer dropped**: an npm `license`/`licenses` field is an authoritative declared SPDX expression, but the extractor only kept values `osslili` could re-detect from fuzzy text — silently dropping valid values like `Proprietary` and `UNLICENSED`. This surfaced as an empty `licenses` list on Python 3.13+, where newer `osslili` no longer fuzzy-matches the bare word. Declared values are now recorded verbatim (`detection_method="declared"`) when `osslili` returns nothing, with `osslili` detection kept as primary for recognised licenses.
+- **Version consistency**: `src/upmex/__init__.py` had drifted to `1.6.6` while `pyproject.toml` was `1.6.7`; both are now `1.6.8`.
+
 ## [1.6.7] - 2025-10-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "upmex"
-version = "1.6.7"
+version = "1.6.8"
 description = "Universal Package Metadata Extractor - Extract metadata from various package formats"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/upmex/__init__.py
+++ b/src/upmex/__init__.py
@@ -1,6 +1,6 @@
 """UPMEX - Universal Package Metadata Extractor."""
 
-__version__ = "1.6.6"
+__version__ = "1.6.8"
 __author__ = "Oscar Valenzuela B."
 __email__ = "oscar.valenzuela.b@gmail.com"
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -39,9 +39,10 @@ License: MIT
     
     def test_cli_version(self, runner):
         """Test version option."""
+        from upmex import __version__
         result = runner.invoke(cli, ['--version'])
         assert result.exit_code == 0
-        assert '1.6.6' in result.output
+        assert __version__ in result.output
     
     def test_info_command(self, runner):
         """Test info command."""
@@ -56,7 +57,8 @@ License: MIT
         result = runner.invoke(cli, ['info', '--json'])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data['version'] == '1.6.6'
+        from upmex import __version__
+        assert data['version'] == __version__
         assert 'supported_packages' in data
     
     def test_detect_command(self, runner, sample_package):


### PR DESCRIPTION
Release 1.6.8.

- Bumps version to 1.6.8 and **realigns** `src/upmex/__init__.py` (was drifted to 1.6.6) with `pyproject.toml`.
- Changelog entry for the npm declared-license fix (merged in #87).

After merge, tag `v1.6.8` to trigger the PyPI publish workflow.