### PR TITLE
feat(maven): resolve coordinates from a file hash when a jar has no POM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.9] - 2026-08-11
+## [1.7.0] - 2026-08-11
 
 ### Added
 - **Maven coordinates resolved from a file hash**: a jar that carries no POM declares no coordinates and has no `<parent>` to follow, so registry mode had nothing to look up — shaded, relocated and repackaged artifacts extracted as `name: "unknown"` with no licence. In registry mode the artifact's SHA-1 is now resolved to coordinates through the Maven Central index, and the published POM is then read for the licence and project metadata, falling through to the existing `<parent>` hop when the resolved POM inherits its licence. `okhttp-4.11.0.jar` now yields `com.squareup.okhttp3:okhttp@4.11.0` and Apache-2.0 instead of nothing. Locally declared data always wins, the offline path makes no requests, lookups are cached by hash for the process lifetime, and `provenance` plus the enrichment record identify what was hash-resolved (closes #91).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.9] - 2026-08-11
+
+### Added
+- **Maven coordinates resolved from a file hash**: a jar that carries no POM declares no coordinates and has no `<parent>` to follow, so registry mode had nothing to look up — shaded, relocated and repackaged artifacts extracted as `name: "unknown"` with no licence. In registry mode the artifact's SHA-1 is now resolved to coordinates through the Maven Central index, and the published POM is then read for the licence and project metadata, falling through to the existing `<parent>` hop when the resolved POM inherits its licence. `okhttp-4.11.0.jar` now yields `com.squareup.okhttp3:okhttp@4.11.0` and Apache-2.0 instead of nothing. Locally declared data always wins, the offline path makes no requests, lookups are cached by hash for the process lifetime, and `provenance` plus the enrichment record identify what was hash-resolved (closes #91).
+
+### Fixed
+- **POM licences no longer dropped when unclassifiable**: a POM declares its licence as prose, and the most common spelling in the ecosystem — `The Apache Software License, Version 2.0` — is not something `osslili` can classify, so the declaration was silently discarded. The declared `<url>` is now tried as a second signal, and a declaration that still cannot be classified is recorded verbatim with `detection_method="declared"` rather than dropped. This mirrors the npm fix in 1.6.8.
+- **Non-ASCII POM text mangled**: remote POMs are served without a charset, so decoding them as text fell back to ISO-8859-1 and corrupted any non-ASCII value. POMs are now parsed from the raw bytes, letting the XML declaration decide.
+- **Registry failures no longer discard local metadata**: an error while fetching a parent POM propagated out of POM parsing, which downgraded a fully described package to the no-POM path. Enrichment failures are now contained.
+- **Failed lookups are no longer cached as misses**: a timeout or rate-limit response was remembered as "hash not found" for the rest of the run. Only definitive answers are cached now, so a transient failure is retried.
+- **Enrichment records are serializable**: the parent-POM enrichment record held `LicenseInfo` objects, which made the JSON output unserializable whenever a parent supplied the licence. Licences are now recorded as SPDX ids in that record.
+
+### Technical
+- New `upmex.api.maven_central` client for coordinate and POM lookups, joining the other registry and API clients
+- `JavaExtractor._fetch_parent_pom` split into fetch, parse and apply steps so both the parent hop and the hash-resolved path share one implementation
+- `BaseExtractor.file_sha1` for extractors that need to hash the artifact they are reading
+
 ## [1.6.8] - 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ Powered by [osslili](https://github.com/SemClone/osslili) v1.5.0+:
 - Optional dependency tracking
 - Version range resolution
 
+### Registry Mode
+
+`--registry` fills gaps from the package's own registry:
+
+```bash
+upmex extract --registry package.jar
+```
+
+- Inherited Maven metadata resolved by following `<parent>` to its POM
+- Coordinates for jars that carry no POM at all — shaded, relocated and
+  repackaged artifacts — resolved from the file's SHA-1 via Maven Central, then
+  used to fetch the licence and project metadata from the published POM
+- Every value records its source in `provenance`, so a hash-resolved licence is
+  distinguishable from a locally declared one
+
 ### API Enrichment
 
 Enhance metadata with third-party APIs:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -438,6 +438,11 @@ extractor = PackageExtractor(config=config)
    ```bash
    upmex extract --registry package.jar
    ```
+   For a jar that carries no POM — shaded, relocated or repackaged artifacts —
+   registry mode resolves the Maven coordinates from the file's SHA-1 via Maven
+   Central and then reads the licence from the published POM. Nothing declared
+   inside the archive is overwritten, and `provenance` records what came from
+   where.
 
 2. **Verify Licenses**: Cross-check with multiple sources
    ```bash

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -440,9 +440,14 @@ extractor = PackageExtractor(config=config)
    ```
    For a jar that carries no POM — shaded, relocated or repackaged artifacts —
    registry mode resolves the Maven coordinates from the file's SHA-1 via Maven
-   Central and then reads the licence from the published POM. Nothing declared
-   inside the archive is overwritten, and `provenance` records what came from
-   where.
+   Central and then reads the licence from the published POM. `provenance`
+   records what came from where.
+
+   Values declared inside the archive win, with one deliberate exception: on this
+   path `name` and `version` are set from the resolved coordinates. A manifest's
+   `Implementation-Title` is a display name rather than a coordinate, and an exact
+   file-hash match identifies the artifact more reliably, which is also what makes
+   the PURL resolvable. The full manifest remains under `raw_metadata`.
 
 2. **Verify Licenses**: Cross-check with multiple sources
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "upmex"
-version = "1.6.9"
+version = "1.7.0"
 description = "Universal Package Metadata Extractor - Extract metadata from various package formats"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "upmex"
-version = "1.6.8"
+version = "1.6.9"
 description = "Universal Package Metadata Extractor - Extract metadata from various package formats"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/upmex/__init__.py
+++ b/src/upmex/__init__.py
@@ -1,6 +1,6 @@
 """UPMEX - Universal Package Metadata Extractor."""
 
-__version__ = "1.6.8"
+__version__ = "1.6.9"
 __author__ = "Oscar Valenzuela B."
 __email__ = "oscar.valenzuela.b@gmail.com"
 

--- a/src/upmex/__init__.py
+++ b/src/upmex/__init__.py
@@ -1,6 +1,6 @@
 """UPMEX - Universal Package Metadata Extractor."""
 
-__version__ = "1.6.9"
+__version__ = "1.7.0"
 __author__ = "Oscar Valenzuela B."
 __email__ = "oscar.valenzuela.b@gmail.com"
 

--- a/src/upmex/api/maven_central.py
+++ b/src/upmex/api/maven_central.py
@@ -1,0 +1,219 @@
+"""Maven Central registry integration for coordinate and POM lookups."""
+
+import xml.etree.ElementTree as ET
+from functools import lru_cache
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+
+DEFAULT_SEARCH_URL = "https://search.maven.org/solrsearch/select"
+DEFAULT_BASE_URL = "https://repo1.maven.org/maven2"
+
+# Maven Central rate-limits the search index aggressively, so every lookup is a
+# single attempt with no retry and results are cached for the process lifetime.
+DEFAULT_TIMEOUT = 10
+SEARCH_ROWS = 20
+
+
+class LookupFailed(Exception):
+    """A lookup did not complete, so its outcome must not be cached.
+
+    Distinguishes a transport failure or a rate-limit response — which says
+    nothing about the artifact and should be retried on a later run — from a
+    definitive "no such hash", which is worth remembering.
+    """
+
+
+@lru_cache(maxsize=512)
+def _search_by_sha1(sha1: str, search_url: str, timeout: int) -> Optional[Tuple[str, str, str, str, int]]:
+    """Look up coordinates for a file SHA-1 in the Maven Central index.
+
+    Returns:
+        Tuple of (group_id, artifact_id, version, packaging, match_count), or None
+        if the index holds no usable match. Immutable so the cached value cannot
+        be mutated by a caller.
+
+    Raises:
+        LookupFailed: if the request did not complete, so nothing is cached
+    """
+    try:
+        params = {'q': f'1:"{sha1}"', 'rows': SEARCH_ROWS, 'wt': 'json'}
+        response = requests.get(search_url, params=params, timeout=timeout)
+    except Exception as e:
+        raise LookupFailed(f"search request failed: {e}") from e
+
+    if response.status_code != 200:
+        raise LookupFailed(f"search returned HTTP {response.status_code}")
+
+    try:
+        payload = response.json()
+    except Exception as e:
+        raise LookupFailed(f"search returned an unreadable body: {e}") from e
+
+    if not isinstance(payload, dict) or not isinstance(payload.get('response'), dict):
+        raise LookupFailed("search returned an unexpected body shape")
+
+    payload = payload['response']
+    docs = [doc for doc in (payload.get('docs') or []) if isinstance(doc, dict)]
+    if not docs:
+        return None
+
+    # A hash can match several coordinates when an artifact is republished or
+    # relocated. The index sorts by score then recency; prefer a jar among the
+    # top matches and report the total so a consumer can see it was ambiguous.
+    doc = next((d for d in docs if d.get('p') == 'jar'), docs[0])
+    group_id = doc.get('g')
+    artifact_id = doc.get('a')
+    version = doc.get('v')
+    if not all(isinstance(field, str) and field for field in (group_id, artifact_id, version)):
+        return None
+
+    packaging = doc.get('p')
+    match_count = payload.get('numFound', len(docs))
+    return (
+        group_id,
+        artifact_id,
+        version,
+        packaging if isinstance(packaging, str) else '',
+        match_count if isinstance(match_count, int) else len(docs),
+    )
+
+
+@lru_cache(maxsize=512)
+def _fetch_pom_bytes(group_id: str, artifact_id: str, version: str, base_url: str, timeout: int) -> Optional[bytes]:
+    """Fetch the raw POM for a set of coordinates.
+
+    Returns the undecoded body: Maven Central serves POMs without a charset, so
+    requests would fall back to ISO-8859-1 and mangle any non-ASCII text. The XML
+    declaration is authoritative, and only the parser can act on it.
+
+    Returns:
+        Raw POM bytes, or None if no POM is published at those coordinates
+
+    Raises:
+        LookupFailed: if the request did not complete, so nothing is cached
+    """
+    try:
+        response = requests.get(
+            _pom_url(group_id, artifact_id, version, base_url),
+            timeout=timeout
+        )
+    except Exception as e:
+        raise LookupFailed(f"POM request failed: {e}") from e
+
+    if response.status_code == 200:
+        return response.content
+    if response.status_code == 404:
+        return None
+
+    raise LookupFailed(f"POM request returned HTTP {response.status_code}")
+
+
+def _pom_url(group_id: str, artifact_id: str, version: str, base_url: str) -> str:
+    """Build the Maven Central URL of a POM."""
+    group_path = group_id.replace('.', '/')
+    return f"{base_url}/{group_path}/{artifact_id}/{version}/{artifact_id}-{version}.pom"
+
+
+def clear_caches() -> None:
+    """Drop the in-process lookup caches. Intended for tests."""
+    _search_by_sha1.cache_clear()
+    _fetch_pom_bytes.cache_clear()
+
+
+class MavenCentralAPI:
+    """Client for Maven Central coordinate and POM lookups."""
+
+    def __init__(self,
+                 search_url: str = DEFAULT_SEARCH_URL,
+                 base_url: str = DEFAULT_BASE_URL,
+                 timeout: int = DEFAULT_TIMEOUT):
+        """Initialize the Maven Central client.
+
+        Args:
+            search_url: Base URL of the Maven Central search index
+            base_url: Base URL of the Maven Central artifact repository
+            timeout: Per-request timeout in seconds
+        """
+        self.search_url = search_url
+        self.base_url = base_url
+        self.timeout = timeout
+
+    def find_by_sha1(self, sha1: str) -> Optional[Dict[str, Any]]:
+        """Resolve Maven coordinates from a file SHA-1.
+
+        Args:
+            sha1: Hex SHA-1 digest of the artifact
+
+        Returns:
+            Dictionary with group_id, artifact_id, version, packaging, match_count
+            and search_url, or None if the hash is unknown or the lookup failed
+        """
+        if not sha1:
+            return None
+
+        try:
+            result = _search_by_sha1(sha1.strip().lower(), self.search_url, self.timeout)
+        except LookupFailed as e:
+            print(f"Error searching Maven Central by hash: {e}")
+            return None
+
+        if not result:
+            return None
+
+        group_id, artifact_id, version, packaging, match_count = result
+        return {
+            'group_id': group_id,
+            'artifact_id': artifact_id,
+            'version': version,
+            'packaging': packaging,
+            'match_count': match_count,
+            'search_url': self.search_url,
+        }
+
+    def fetch_pom(self, group_id: str, artifact_id: str, version: str) -> Optional[Tuple[Any, str, str]]:
+        """Fetch and parse the POM for a set of coordinates.
+
+        Args:
+            group_id: Maven group ID
+            artifact_id: Maven artifact ID
+            version: Maven version
+
+        Returns:
+            Tuple of (parsed XML root, raw POM text, POM URL) or None. The root is
+            returned alongside the text so a caller can follow <parent> itself.
+        """
+        if not (group_id and artifact_id and version):
+            return None
+
+        try:
+            pom_bytes = _fetch_pom_bytes(group_id, artifact_id, version, self.base_url, self.timeout)
+        except LookupFailed as e:
+            print(f"Error fetching POM from Maven Central: {e}")
+            return None
+
+        if not pom_bytes:
+            return None
+
+        try:
+            root = ET.fromstring(pom_bytes)
+        except Exception as e:
+            print(f"Error parsing POM from Maven Central: {e}")
+            return None
+
+        # Only the header comments are read as text, and those are ASCII patterns
+        pom_text = pom_bytes.decode('utf-8', errors='replace')
+        return (root, pom_text, self.pom_url(group_id, artifact_id, version))
+
+    def pom_url(self, group_id: str, artifact_id: str, version: str) -> str:
+        """Build the Maven Central URL of a POM.
+
+        Args:
+            group_id: Maven group ID
+            artifact_id: Maven artifact ID
+            version: Maven version
+
+        Returns:
+            Fully qualified POM URL
+        """
+        return _pom_url(group_id, artifact_id, version, self.base_url)

--- a/src/upmex/api/maven_central.py
+++ b/src/upmex/api/maven_central.py
@@ -54,29 +54,46 @@ def _search_by_sha1(sha1: str, search_url: str, timeout: int) -> Optional[Tuple[
         raise LookupFailed("search returned an unexpected body shape")
 
     payload = payload['response']
-    docs = [doc for doc in (payload.get('docs') or []) if isinstance(doc, dict)]
-    if not docs:
+    docs = payload.get('docs')
+    if docs is None:
+        docs = []
+    if not isinstance(docs, list):
+        raise LookupFailed("search returned an unexpected docs shape")
+
+    candidates = [doc for doc in docs if isinstance(doc, dict)]
+    if not candidates:
+        if docs:
+            # Documents came back in a shape we cannot read, which says nothing
+            # about the artifact
+            raise LookupFailed("search returned no readable documents")
         return None
 
     # A hash can match several coordinates when an artifact is republished or
     # relocated. The index sorts by score then recency; prefer a jar among the
-    # top matches and report the total so a consumer can see it was ambiguous.
-    doc = next((d for d in docs if d.get('p') == 'jar'), docs[0])
-    group_id = doc.get('g')
-    artifact_id = doc.get('a')
-    version = doc.get('v')
-    if not all(isinstance(field, str) and field for field in (group_id, artifact_id, version)):
-        return None
+    # matches and report the total so a consumer can see it was ambiguous.
+    ordered = ([doc for doc in candidates if doc.get('p') == 'jar'] +
+               [doc for doc in candidates if doc.get('p') != 'jar'])
 
-    packaging = doc.get('p')
-    match_count = payload.get('numFound', len(docs))
-    return (
-        group_id,
-        artifact_id,
-        version,
-        packaging if isinstance(packaging, str) else '',
-        match_count if isinstance(match_count, int) else len(docs),
-    )
+    for doc in ordered:
+        group_id = doc.get('g')
+        artifact_id = doc.get('a')
+        version = doc.get('v')
+        if not all(isinstance(field, str) and field for field in (group_id, artifact_id, version)):
+            continue
+
+        packaging = doc.get('p')
+        match_count = payload.get('numFound')
+        return (
+            group_id,
+            artifact_id,
+            version,
+            packaging if isinstance(packaging, str) else '',
+            match_count if isinstance(match_count, int) else len(candidates),
+        )
+
+    # Matches exist but none carries complete coordinates, so the response is
+    # malformed rather than a definitive "this hash is unknown"
+    raise LookupFailed("search returned no complete coordinates")
 
 
 @lru_cache(maxsize=512)
@@ -102,6 +119,18 @@ def _fetch_pom_bytes(group_id: str, artifact_id: str, version: str, base_url: st
         raise LookupFailed(f"POM request failed: {e}") from e
 
     if response.status_code == 200:
+        # A proxy or CDN can answer 200 with an error page, which may even be
+        # well-formed XML. Caching that would stand in for the POM for the rest of
+        # the run, so the body has to look like a POM before it counts as an answer.
+        try:
+            root = ET.fromstring(response.content)
+        except Exception as e:
+            raise LookupFailed(f"POM body is not readable XML: {e}") from e
+
+        # The tag carries the POM namespace, so compare the local name
+        if root.tag.rsplit('}', 1)[-1] != 'project':
+            raise LookupFailed(f"POM body is rooted at <{root.tag}>, not <project>")
+
         return response.content
     if response.status_code == 404:
         return None

--- a/src/upmex/cli.py
+++ b/src/upmex/cli.py
@@ -510,7 +510,9 @@ def info(ctx, output_json):
         ],
         "registry_integrations": {
             "implemented": ["maven_central"],
-            "note": "Direct package registry API calls for metadata enrichment"
+            "note": "Direct package registry API calls for metadata enrichment "
+                    "(Maven Central also resolves coordinates from a file hash "
+                    "when a jar carries no POM)"
         },
         "api_integrations": {
             "implemented": ["clearlydefined", "ecosystems", "purldb", "vulnerablecode"],

--- a/src/upmex/extractors/base.py
+++ b/src/upmex/extractors/base.py
@@ -1,5 +1,6 @@
 """Base extractor class for all package types."""
 
+import hashlib
 import os
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any, List, Union
@@ -71,6 +72,24 @@ class BaseExtractor(ABC):
         """
         return parse_author_list(authors)
     
+    def file_sha1(self, file_path: str) -> Optional[str]:
+        """Calculate the SHA-1 of a file.
+
+        Args:
+            file_path: Path to the file
+
+        Returns:
+            Hex digest, or None if the file could not be read
+        """
+        try:
+            digest = hashlib.sha1()
+            with open(file_path, 'rb') as f:
+                for chunk in iter(lambda: f.read(8192), b''):
+                    digest.update(chunk)
+            return digest.hexdigest()
+        except Exception:
+            return None
+
     def detect_licenses_from_text(self,
                                  text: str,
                                  filename: Optional[str] = None) -> List[LicenseInfo]:

--- a/src/upmex/extractors/java_extractor.py
+++ b/src/upmex/extractors/java_extractor.py
@@ -265,6 +265,9 @@ class JavaExtractor(BaseExtractor):
             package_path: Path to the archive
             metadata: Metadata to enrich in place
         """
+        # Hashed here rather than reusing PackageExtractor's digest, which is not
+        # assigned until after extract() returns. An extractor also has to work
+        # when used directly, which is how consumers reach this path.
         sha1 = self.file_sha1(package_path)
         if not sha1:
             return
@@ -557,9 +560,9 @@ class JavaExtractor(BaseExtractor):
             # Extract SCM/repository
             scm = root.find('.//maven:scm', ns) or root.find('.//scm')
             if scm is not None:
-                repo_url = (scm.findtext('maven:url', None, ns) or 
+                repo_url = (scm.findtext('maven:url', None, ns) or
                            scm.findtext('url') or
-                           scm.findtext('maven:connection', None, ns) or 
+                           scm.findtext('maven:connection', None, ns) or
                            scm.findtext('connection'))
                 if repo_url:
                     if repo_url.startswith('scm:'):
@@ -598,12 +601,12 @@ class JavaExtractor(BaseExtractor):
                     if role_text:
                         maintainer_info['role'] = role_text
                     maintainers.append(maintainer_info)
-            
+
             if developers:
                 pom_data['authors'] = developers
             if maintainers:
                 pom_data['maintainers'] = maintainers
-            
+
             # Also extract contributors as additional maintainers
             for contrib in root.findall('.//maven:contributor', ns) or root.findall('.//contributor'):
                 contrib_name = contrib.findtext('maven:name', None, ns) or contrib.findtext('name')
@@ -622,17 +625,17 @@ class JavaExtractor(BaseExtractor):
                     if 'maintainers' not in pom_data:
                         pom_data['maintainers'] = []
                     pom_data['maintainers'].append(maintainer_info)
-            
+
             # Extract description
             description = root.findtext('.//maven:description', None, ns) or root.findtext('.//description')
             if description:
                 pom_data['description'] = description
-            
+
             # Extract homepage
             homepage = root.findtext('.//maven:url', None, ns) or root.findtext('.//url')
             if homepage:
                 pom_data['homepage'] = homepage
-            
+
             # Extract licenses
             licenses_elem = root.find('.//maven:licenses', ns) or root.find('.//licenses')
             if licenses_elem is not None:
@@ -645,7 +648,7 @@ class JavaExtractor(BaseExtractor):
                 )
                 if licenses:
                     pom_data['licenses'] = licenses
-            
+
             # Also check for license/author info in header comments
             header_data = self._parse_pom_header(pom_text)
             if header_data:
@@ -655,11 +658,16 @@ class JavaExtractor(BaseExtractor):
                     # Convert header license text to proper format
                     license_infos = self.detect_licenses_from_text(
                         self._format_license_text(header_data['license']),
-                        filename='pom.xml'
+                        filename=license_filename
                     )
                     if license_infos:
+                        # Same source attribution as a declared <licenses> entry,
+                        # so a consumer can tell which POM it came from
+                        for info in license_infos:
+                            info.detection_method = detection_method
+                            info.file_path = license_file_path
                         pom_data['licenses'] = license_infos
-            
+
         except Exception as e:
             print(f"Error parsing POM metadata: {e}")
 

--- a/src/upmex/extractors/java_extractor.py
+++ b/src/upmex/extractors/java_extractor.py
@@ -3,11 +3,17 @@
 import zipfile
 import xml.etree.ElementTree as ET
 import re
-import requests
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional
 from .base import BaseExtractor
-from ..core.models import PackageMetadata, PackageType, NO_ASSERTION
+from ..api.maven_central import MavenCentralAPI
+from ..core.models import (
+    LicenseConfidenceLevel,
+    LicenseInfo,
+    PackageMetadata,
+    PackageType,
+    NO_ASSERTION,
+)
 
 
 class JavaExtractor(BaseExtractor):
@@ -17,6 +23,7 @@ class JavaExtractor(BaseExtractor):
         """Initialize the Java extractor."""
         super().__init__(registry_mode)
         self.maven_central_url = "https://repo1.maven.org/maven2"
+        self._maven_central = MavenCentralAPI(base_url=self.maven_central_url)
     
     def extract(self, package_path: str) -> PackageMetadata:
         """Extract metadata from Java package."""
@@ -44,7 +51,16 @@ class JavaExtractor(BaseExtractor):
                         if lic.spdx_id not in existing_spdx_ids:
                             metadata.licenses.append(lic)
                             existing_spdx_ids.add(lic.spdx_id)
-                
+
+                # An archive with no POM has no coordinates and no <parent> to
+                # follow, so the file hash is the only handle on its identity.
+                if pom_metadata is None and self.registry_mode:
+                    try:
+                        self._resolve_from_file_hash(package_path, metadata)
+                    except Exception as e:
+                        # Optional enrichment must not cost us the local metadata
+                        print(f"Error resolving coordinates from file hash: {e}")
+
                 # Extract copyright information
                 import tempfile
                 import os
@@ -148,21 +164,13 @@ class JavaExtractor(BaseExtractor):
                     # Extract license from embedded POM first
                     licenses_elem = root.find('.//maven:licenses', ns) or root.find('.//licenses')
                     if licenses_elem is not None:
-                        license_elems = licenses_elem.findall('./maven:license', ns) or licenses_elem.findall('./license')
-                        for license_elem in license_elems:
-                            license_name = license_elem.findtext('maven:name', '', ns) or license_elem.findtext('name', '')
-                            if license_name:
-                                # Format license text for better osslili detection
-                                if len(license_name) < 20 and ':' not in license_name:
-                                    formatted_text = f"License: {license_name}"
-                                else:
-                                    formatted_text = license_name
-                                license_infos = self.detect_licenses_from_text(
-                                    formatted_text,
-                                    filename='pom.xml'
-                                )
-                                if license_infos:
-                                    metadata.licenses.extend(license_infos)
+                        metadata.licenses.extend(self._detect_pom_licenses(
+                            licenses_elem,
+                            ns,
+                            detection_method=None,
+                            file_path='pom.xml',
+                            filename='pom.xml'
+                        ))
                     
                     # Check if we have real data or just NO-ASSERTION placeholders
                     has_real_authors = metadata.authors and any(
@@ -173,52 +181,7 @@ class JavaExtractor(BaseExtractor):
                     
                     # If missing critical data and registry mode is enabled, fetch parent POM
                     if self.registry_mode and (not has_real_authors or not has_real_repository or not metadata.licenses):
-                        parent = root.find('./maven:parent', ns) or root.find('./parent')
-                        if parent is not None:
-                            parent_group = parent.findtext('maven:groupId', '', ns) or parent.findtext('groupId', '')
-                            parent_artifact = parent.findtext('maven:artifactId', '', ns) or parent.findtext('artifactId', '')
-                            parent_version = parent.findtext('maven:version', '', ns) or parent.findtext('version', '')
-                            
-                            if parent_group and parent_artifact and parent_version:
-                                parent_metadata = self._fetch_parent_pom(parent_group, parent_artifact, parent_version)
-                                if parent_metadata:
-                                    parent_pom_url = f"https://repo1.maven.org/maven2/{parent_group.replace('.', '/')}/{parent_artifact}/{parent_version}/{parent_artifact}-{parent_version}.pom"
-                                    applied_fields = []
-
-                                    # Only replace NO-ASSERTION values, don't overwrite real data
-                                    if not metadata.description and parent_metadata.get('description'):
-                                        metadata.description = parent_metadata['description']
-                                        metadata.provenance['description'] = f"parent_pom:{parent_pom_url}"
-                                        applied_fields.append('description')
-                                    if not has_real_authors and parent_metadata.get('authors'):
-                                        metadata.authors = parent_metadata['authors']
-                                        metadata.provenance['authors'] = f"parent_pom:{parent_pom_url}"
-                                        applied_fields.append('authors')
-                                    if not metadata.maintainers and parent_metadata.get('maintainers'):
-                                        metadata.maintainers = parent_metadata['maintainers']
-                                        metadata.provenance['maintainers'] = f"parent_pom:{parent_pom_url}"
-                                        applied_fields.append('maintainers')
-                                    if not has_real_repository and parent_metadata.get('repository'):
-                                        metadata.repository = parent_metadata['repository']
-                                        metadata.provenance['repository'] = f"parent_pom:{parent_pom_url}"
-                                        applied_fields.append('repository')
-                                    if not metadata.homepage and parent_metadata.get('homepage'):
-                                        metadata.homepage = parent_metadata['homepage']
-                                        metadata.provenance['homepage'] = f"parent_pom:{parent_pom_url}"
-                                        applied_fields.append('homepage')
-                                    if not metadata.licenses and parent_metadata.get('licenses'):
-                                        metadata.licenses = parent_metadata['licenses']
-                                        metadata.provenance['licenses'] = f"parent_pom:{parent_pom_url}"
-                                        applied_fields.append('licenses')
-
-                                    # Track registry enrichment
-                                    if applied_fields:
-                                        metadata.add_enrichment(
-                                            source="maven_central",
-                                            source_type="registry",
-                                            data=parent_metadata,
-                                            applied_fields=applied_fields
-                                        )
+                        self._apply_parent_pom(root, ns, metadata)
 
                     # ClearlyDefined fallback enrichment in registry mode
                     if self.registry_mode:
@@ -292,170 +255,415 @@ class JavaExtractor(BaseExtractor):
         
         return metadata
     
-    def _fetch_parent_pom(self, group_id: str, artifact_id: str, version: str) -> Optional[Dict[str, Any]]:
-        """Fetch parent POM from Maven Central.
-        
+    def _resolve_from_file_hash(self, package_path: str, metadata: PackageMetadata) -> None:
+        """Resolve Maven coordinates from the artifact's SHA-1 and enrich from its POM.
+
+        Used for archives that carry no POM: shaded, relocated and repackaged jars
+        declare no coordinates locally, so there is nothing to look a POM up by.
+
         Args:
-            group_id: Maven group ID
-            artifact_id: Maven artifact ID  
-            version: Maven version
-            
+            package_path: Path to the archive
+            metadata: Metadata to enrich in place
+        """
+        sha1 = self.file_sha1(package_path)
+        if not sha1:
+            return
+
+        coordinates = self._maven_central.find_by_sha1(sha1)
+        if not coordinates:
+            return
+
+        group_id = coordinates['group_id']
+        artifact_id = coordinates['artifact_id']
+        version = coordinates['version']
+        hash_source = f"maven_central_hash:{coordinates['search_url']}"
+
+        # An exact file-hash match identifies the artifact more reliably than the
+        # manifest strings the fallback path guessed from, and coordinates are what
+        # make the PURL resolvable. The manifest is still kept in raw_metadata.
+        metadata.name = f"{group_id}:{artifact_id}"
+        metadata.provenance['name'] = hash_source
+        metadata.version = version
+        metadata.provenance['version'] = hash_source
+        applied_fields = ['name', 'version']
+
+        fetched = self._maven_central.fetch_pom(group_id, artifact_id, version)
+        if fetched:
+            root, pom_text, pom_url = fetched
+            ns = {'maven': 'http://maven.apache.org/POM/4.0.0'}
+            pom_data = self._parse_pom_metadata(
+                root,
+                pom_text,
+                detection_method='maven_central_pom',
+                license_file_path=f"maven_central:{artifact_id}-{version}.pom",
+                license_filename='pom.xml'
+            )
+            applied_fields.extend(
+                self._apply_pom_data(metadata, pom_data, f"maven_central_pom:{pom_url}")
+            )
+
+            # The resolved POM may inherit its licences, so fall through to the
+            # existing parent hop when it declares none of its own.
+            if not metadata.licenses:
+                self._apply_parent_pom(root, ns, metadata)
+
+        metadata.add_enrichment(
+            source="maven_central",
+            source_type="registry",
+            data={
+                'sha1': sha1,
+                'group_id': group_id,
+                'artifact_id': artifact_id,
+                'version': version,
+                'packaging': coordinates['packaging'],
+                'match_count': coordinates['match_count'],
+                'resolved_by': 'file_hash'
+            },
+            applied_fields=applied_fields
+        )
+
+    def _apply_parent_pom(self, root: Any, ns: Dict[str, str], metadata: PackageMetadata) -> List[str]:
+        """Follow a POM's <parent> and fill missing fields from it.
+
+        Args:
+            root: Parsed POM root element
+            ns: XML namespace map
+            metadata: Metadata to enrich in place
+
         Returns:
-            Dictionary with extracted parent metadata or None
+            List of fields that were filled from the parent POM
         """
         try:
-            # Construct Maven Central URL
-            group_path = group_id.replace('.', '/')
-            pom_url = f"{self.maven_central_url}/{group_path}/{artifact_id}/{version}/{artifact_id}-{version}.pom"
-            
-            # Fetch POM
-            response = requests.get(pom_url, timeout=10)
-            if response.status_code == 200:
-                # Parse POM content
-                root = ET.fromstring(response.content)
-                ns = {'maven': 'http://maven.apache.org/POM/4.0.0'}
-                
-                parent_data = {}
-                
-                # Extract SCM/repository
-                scm = root.find('.//maven:scm', ns) or root.find('.//scm')
-                if scm is not None:
-                    repo_url = (scm.findtext('maven:url', None, ns) or 
-                               scm.findtext('url') or
-                               scm.findtext('maven:connection', None, ns) or 
-                               scm.findtext('connection'))
-                    if repo_url:
-                        if repo_url.startswith('scm:'):
-                            repo_url = repo_url.split(':', 2)[-1]
-                        parent_data['repository'] = repo_url
-                
-                # Extract developers (as both authors and maintainers)
-                developers = []
-                maintainers = []
-                for dev in root.findall('.//maven:developer', ns) or root.findall('.//developer'):
-                    dev_name = dev.findtext('maven:name', None, ns) or dev.findtext('name')
-                    dev_email = dev.findtext('maven:email', None, ns) or dev.findtext('email')
-                    dev_id = dev.findtext('maven:id', None, ns) or dev.findtext('id')
-                    dev_org = dev.findtext('maven:organization', None, ns) or dev.findtext('organization')
-                    dev_role = dev.find('maven:roles/maven:role', ns) or dev.find('roles/role')
-                    role_text = dev_role.text if dev_role is not None else None
-                    
-                    # Use id or organization as fallback for name
-                    if not dev_name:
-                        if dev_org:
-                            dev_name = dev_org
-                        elif dev_id:
-                            dev_name = dev_id
-                    
-                    if dev_name or dev_email:
-                        dev_info = {
-                            'name': dev_name or NO_ASSERTION,
-                            'email': dev_email or NO_ASSERTION
-                        }
-                        developers.append(dev_info)
-                        
-                        # Also add as maintainer with organization info
-                        maintainer_info = dev_info.copy()
-                        if dev_org:
-                            maintainer_info['organization'] = dev_org
-                        if role_text:
-                            maintainer_info['role'] = role_text
-                        maintainers.append(maintainer_info)
-                
-                if developers:
-                    parent_data['authors'] = developers
-                if maintainers:
-                    parent_data['maintainers'] = maintainers
-                
-                # Also extract contributors as additional maintainers
-                for contrib in root.findall('.//maven:contributor', ns) or root.findall('.//contributor'):
-                    contrib_name = contrib.findtext('maven:name', None, ns) or contrib.findtext('name')
-                    contrib_email = contrib.findtext('maven:email', None, ns) or contrib.findtext('email')
-                    contrib_org = contrib.findtext('maven:organization', None, ns) or contrib.findtext('organization')
-                    
-                    if contrib_name or contrib_email:
-                        maintainer_info = {
-                            'name': contrib_name or NO_ASSERTION,
-                            'email': contrib_email or NO_ASSERTION
-                        }
-                        if contrib_org:
-                            maintainer_info['organization'] = contrib_org
-                        maintainer_info['role'] = 'contributor'
-                        
-                        if 'maintainers' not in parent_data:
-                            parent_data['maintainers'] = []
-                        parent_data['maintainers'].append(maintainer_info)
-                
-                # Extract description
-                description = root.findtext('.//maven:description', None, ns) or root.findtext('.//description')
-                if description:
-                    parent_data['description'] = description
-                
-                # Extract homepage
-                homepage = root.findtext('.//maven:url', None, ns) or root.findtext('.//url')
-                if homepage:
-                    parent_data['homepage'] = homepage
-                
-                # Extract licenses
-                licenses = []
-                licenses_elem = root.find('.//maven:licenses', ns) or root.find('.//licenses')
-                if licenses_elem is not None:
-                    license_elems = licenses_elem.findall('maven:license', ns)  # Remove ./ prefix
-                    if not license_elems:
-                        license_elems = licenses_elem.findall('license')  # Try without namespace
-                    
-                    for license_elem in license_elems:
-                        license_name = license_elem.findtext('maven:name', '', ns) or license_elem.findtext('name', '')
-                        if license_name:
-                            # Use the same license detection as in main extraction
-                            try:
-                                # Format license text for better osslili detection
-                                if len(license_name) < 20 and ':' not in license_name:
-                                    formatted_text = f"License: {license_name}"
-                                else:
-                                    formatted_text = license_name
-                                license_infos = self.detect_licenses_from_text(
-                                    formatted_text,
-                                    filename='parent_pom.xml'
-                                )
-                                if license_infos:
-                                    # Update detection method to clarify source
-                                    for info in license_infos:
-                                        info.detection_method = 'parent_pom_regex'
-                                        info.file_path = f"parent:{artifact_id}-{version}.pom"
-                                    licenses.extend(license_infos)
-                            except Exception as lic_err:
-                                print(f"Error detecting license '{license_name}': {lic_err}")
-                
-                if licenses:
-                    parent_data['licenses'] = licenses
-                
-                # Also check for license/author info in header comments
-                header_data = self._parse_pom_header(response.text)
-                if header_data:
-                    if 'authors' in header_data and not parent_data.get('authors'):
-                        parent_data['authors'] = header_data['authors']
-                    if 'license' in header_data and not parent_data.get('licenses'):
-                        # Convert header license text to proper format
-                        license_text = header_data['license']
-                        # Format license text for better osslili detection
-                        if len(license_text) < 20 and ':' not in license_text:
-                            formatted_text = f"License: {license_text}"
-                        else:
-                            formatted_text = license_text
-                        license_infos = self.detect_licenses_from_text(
-                            formatted_text,
-                            filename='pom.xml'
-                        )
-                        if license_infos:
-                            parent_data['licenses'] = license_infos
-                
-                return parent_data
-                
+            return self._fetch_and_apply_parent_pom(root, ns, metadata)
         except Exception as e:
-            print(f"Error fetching parent POM: {e}")
-        
-        return None
+            # Enrichment is optional: a registry problem must never cost the
+            # caller the metadata that was parsed out of the archive itself.
+            print(f"Error applying parent POM: {e}")
+            return []
+
+    def _fetch_and_apply_parent_pom(self, root: Any, ns: Dict[str, str], metadata: PackageMetadata) -> List[str]:
+        """Fetch the parent POM named by a POM and apply its data.
+
+        Args:
+            root: Parsed POM root element
+            ns: XML namespace map
+            metadata: Metadata to enrich in place
+
+        Returns:
+            List of fields that were filled from the parent POM
+        """
+        parent = root.find('./maven:parent', ns) or root.find('./parent')
+        if parent is None:
+            return []
+
+        parent_group = parent.findtext('maven:groupId', '', ns) or parent.findtext('groupId', '')
+        parent_artifact = parent.findtext('maven:artifactId', '', ns) or parent.findtext('artifactId', '')
+        parent_version = parent.findtext('maven:version', '', ns) or parent.findtext('version', '')
+        if not (parent_group and parent_artifact and parent_version):
+            return []
+
+        fetched = self._maven_central.fetch_pom(parent_group, parent_artifact, parent_version)
+        if not fetched:
+            return []
+
+        parent_root, parent_text, parent_pom_url = fetched
+        parent_metadata = self._parse_pom_metadata(
+            parent_root,
+            parent_text,
+            detection_method='parent_pom_regex',
+            license_file_path=f"parent:{parent_artifact}-{parent_version}.pom",
+            license_filename='parent_pom.xml'
+        )
+        applied_fields = self._apply_pom_data(metadata, parent_metadata, f"parent_pom:{parent_pom_url}")
+
+        # Track registry enrichment
+        if applied_fields:
+            metadata.add_enrichment(
+                source="maven_central",
+                source_type="registry",
+                data=self._enrichment_payload(parent_metadata),
+                applied_fields=applied_fields
+            )
+
+        return applied_fields
+
+    def _apply_pom_data(self, metadata: PackageMetadata, pom_data: Dict[str, Any], source: str) -> List[str]:
+        """Fill empty metadata fields from a remotely fetched POM.
+
+        Locally declared data always wins: only fields that are missing or hold
+        NO-ASSERTION are replaced.
+
+        Args:
+            metadata: Metadata to enrich in place
+            pom_data: Parsed POM data
+            source: Provenance string recorded for each field that is filled
+
+        Returns:
+            List of fields that were filled
+        """
+        has_real_authors = metadata.authors and any(
+            author.get('name') != NO_ASSERTION or author.get('email') != NO_ASSERTION
+            for author in metadata.authors
+        )
+        has_real_repository = metadata.repository and metadata.repository != NO_ASSERTION
+
+        applied_fields = []
+
+        if not metadata.description and pom_data.get('description'):
+            metadata.description = pom_data['description']
+            metadata.provenance['description'] = source
+            applied_fields.append('description')
+        if not has_real_authors and pom_data.get('authors'):
+            metadata.authors = pom_data['authors']
+            metadata.provenance['authors'] = source
+            applied_fields.append('authors')
+        if not metadata.maintainers and pom_data.get('maintainers'):
+            metadata.maintainers = pom_data['maintainers']
+            metadata.provenance['maintainers'] = source
+            applied_fields.append('maintainers')
+        if not has_real_repository and pom_data.get('repository'):
+            metadata.repository = pom_data['repository']
+            metadata.provenance['repository'] = source
+            applied_fields.append('repository')
+        if not metadata.homepage and pom_data.get('homepage'):
+            metadata.homepage = pom_data['homepage']
+            metadata.provenance['homepage'] = source
+            applied_fields.append('homepage')
+        if not metadata.licenses and pom_data.get('licenses'):
+            metadata.licenses = pom_data['licenses']
+            metadata.provenance['licenses'] = source
+            applied_fields.append('licenses')
+
+        return applied_fields
+
+    def _enrichment_payload(self, pom_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Reduce parsed POM data to JSON-serializable values for the audit record.
+
+        Args:
+            pom_data: Parsed POM data, which may hold LicenseInfo objects
+
+        Returns:
+            Dictionary safe to serialize in the enrichment record
+        """
+        payload = {key: value for key, value in pom_data.items() if key != 'licenses'}
+        if pom_data.get('licenses'):
+            payload['licenses'] = [
+                lic.spdx_id for lic in pom_data['licenses'] if lic.spdx_id
+            ]
+        return payload
+
+    def _detect_pom_licenses(self,
+                             licenses_elem: Any,
+                             ns: Dict[str, str],
+                             detection_method: Optional[str],
+                             file_path: str,
+                             filename: str) -> List[LicenseInfo]:
+        """Detect the licenses declared in a POM's <licenses> block.
+
+        A POM declares its license as prose rather than an SPDX id, and the common
+        spellings ("The Apache Software License, Version 2.0") are not something
+        osslili can classify. So the declared <url> is tried as a second signal,
+        and a declaration osslili cannot classify at all is recorded verbatim
+        rather than dropped — as the npm extractor does for its declared field.
+
+        Args:
+            licenses_elem: The POM's <licenses> element
+            ns: XML namespace map
+            detection_method: Overrides osslili's detection method when set
+            file_path: Source path recorded on each detected license
+            filename: Filename hint passed to license detection
+
+        Returns:
+            List of detected licenses
+        """
+        licenses = []
+        license_elems = (licenses_elem.findall('./maven:license', ns) or
+                         licenses_elem.findall('./license'))
+
+        for license_elem in license_elems:
+            license_name = license_elem.findtext('maven:name', '', ns) or license_elem.findtext('name', '')
+            if not license_name:
+                continue
+
+            license_url = license_elem.findtext('maven:url', '', ns) or license_elem.findtext('url', '')
+            try:
+                detected = self.detect_licenses_from_text(
+                    self._format_license_text(license_name),
+                    filename=filename
+                )
+                if not detected and license_url:
+                    detected = self.detect_licenses_from_text(
+                        f"License: {license_url}",
+                        filename=filename
+                    )
+
+                if detected:
+                    for info in detected:
+                        if detection_method:
+                            info.detection_method = detection_method
+                        info.file_path = file_path
+                    licenses.extend(detected)
+                else:
+                    licenses.append(LicenseInfo(
+                        spdx_id=license_name,
+                        name=license_name,
+                        confidence=1.0,
+                        confidence_level=LicenseConfidenceLevel.HIGH,
+                        detection_method='declared',
+                        file_path=file_path
+                    ))
+            except Exception as lic_err:
+                print(f"Error detecting license '{license_name}': {lic_err}")
+
+        return licenses
+
+    @staticmethod
+    def _format_license_text(text: str) -> str:
+        """Format a short license declaration for better osslili detection.
+
+        Args:
+            text: Declared license name or URL
+
+        Returns:
+            Text prefixed with a license tag when it is short enough to be an id
+        """
+        if len(text) < 20 and ':' not in text:
+            return f"License: {text}"
+        return text
+
+    def _parse_pom_metadata(self,
+                            root: Any,
+                            pom_text: str,
+                            detection_method: str,
+                            license_file_path: str,
+                            license_filename: str) -> Dict[str, Any]:
+        """Extract metadata from a POM fetched from Maven Central.
+
+        Args:
+            root: Parsed POM root element
+            pom_text: Raw POM XML, used for header comment parsing
+            detection_method: Detection method recorded on detected licenses
+            license_file_path: Source path recorded on detected licenses
+            license_filename: Filename hint passed to license detection
+
+        Returns:
+            Dictionary with extracted POM metadata
+        """
+        try:
+            ns = {'maven': 'http://maven.apache.org/POM/4.0.0'}
+
+            pom_data = {}
+
+            # Extract SCM/repository
+            scm = root.find('.//maven:scm', ns) or root.find('.//scm')
+            if scm is not None:
+                repo_url = (scm.findtext('maven:url', None, ns) or 
+                           scm.findtext('url') or
+                           scm.findtext('maven:connection', None, ns) or 
+                           scm.findtext('connection'))
+                if repo_url:
+                    if repo_url.startswith('scm:'):
+                        repo_url = repo_url.split(':', 2)[-1]
+                    pom_data['repository'] = repo_url
+            
+            # Extract developers (as both authors and maintainers)
+            developers = []
+            maintainers = []
+            for dev in root.findall('.//maven:developer', ns) or root.findall('.//developer'):
+                dev_name = dev.findtext('maven:name', None, ns) or dev.findtext('name')
+                dev_email = dev.findtext('maven:email', None, ns) or dev.findtext('email')
+                dev_id = dev.findtext('maven:id', None, ns) or dev.findtext('id')
+                dev_org = dev.findtext('maven:organization', None, ns) or dev.findtext('organization')
+                dev_role = dev.find('maven:roles/maven:role', ns) or dev.find('roles/role')
+                role_text = dev_role.text if dev_role is not None else None
+                
+                # Use id or organization as fallback for name
+                if not dev_name:
+                    if dev_org:
+                        dev_name = dev_org
+                    elif dev_id:
+                        dev_name = dev_id
+                
+                if dev_name or dev_email:
+                    dev_info = {
+                        'name': dev_name or NO_ASSERTION,
+                        'email': dev_email or NO_ASSERTION
+                    }
+                    developers.append(dev_info)
+                    
+                    # Also add as maintainer with organization info
+                    maintainer_info = dev_info.copy()
+                    if dev_org:
+                        maintainer_info['organization'] = dev_org
+                    if role_text:
+                        maintainer_info['role'] = role_text
+                    maintainers.append(maintainer_info)
+            
+            if developers:
+                pom_data['authors'] = developers
+            if maintainers:
+                pom_data['maintainers'] = maintainers
+            
+            # Also extract contributors as additional maintainers
+            for contrib in root.findall('.//maven:contributor', ns) or root.findall('.//contributor'):
+                contrib_name = contrib.findtext('maven:name', None, ns) or contrib.findtext('name')
+                contrib_email = contrib.findtext('maven:email', None, ns) or contrib.findtext('email')
+                contrib_org = contrib.findtext('maven:organization', None, ns) or contrib.findtext('organization')
+                
+                if contrib_name or contrib_email:
+                    maintainer_info = {
+                        'name': contrib_name or NO_ASSERTION,
+                        'email': contrib_email or NO_ASSERTION
+                    }
+                    if contrib_org:
+                        maintainer_info['organization'] = contrib_org
+                    maintainer_info['role'] = 'contributor'
+                    
+                    if 'maintainers' not in pom_data:
+                        pom_data['maintainers'] = []
+                    pom_data['maintainers'].append(maintainer_info)
+            
+            # Extract description
+            description = root.findtext('.//maven:description', None, ns) or root.findtext('.//description')
+            if description:
+                pom_data['description'] = description
+            
+            # Extract homepage
+            homepage = root.findtext('.//maven:url', None, ns) or root.findtext('.//url')
+            if homepage:
+                pom_data['homepage'] = homepage
+            
+            # Extract licenses
+            licenses_elem = root.find('.//maven:licenses', ns) or root.find('.//licenses')
+            if licenses_elem is not None:
+                licenses = self._detect_pom_licenses(
+                    licenses_elem,
+                    ns,
+                    detection_method=detection_method,
+                    file_path=license_file_path,
+                    filename=license_filename
+                )
+                if licenses:
+                    pom_data['licenses'] = licenses
+            
+            # Also check for license/author info in header comments
+            header_data = self._parse_pom_header(pom_text)
+            if header_data:
+                if 'authors' in header_data and not pom_data.get('authors'):
+                    pom_data['authors'] = header_data['authors']
+                if 'license' in header_data and not pom_data.get('licenses'):
+                    # Convert header license text to proper format
+                    license_infos = self.detect_licenses_from_text(
+                        self._format_license_text(header_data['license']),
+                        filename='pom.xml'
+                    )
+                    if license_infos:
+                        pom_data['licenses'] = license_infos
+            
+        except Exception as e:
+            print(f"Error parsing POM metadata: {e}")
+
+        return pom_data
     
     def _parse_pom_header(self, pom_content: str) -> Optional[Dict[str, Any]]:
         """Parse license and author information from POM header comments.

--- a/tests/integration/test_extractors.py
+++ b/tests/integration/test_extractors.py
@@ -1,6 +1,7 @@
 """Integration tests for package extractors."""
 
 import pytest
+import requests
 import tempfile
 import zipfile
 import tarfile
@@ -231,15 +232,46 @@ class TestRegistryMode:
         
         mock_get.return_value.status_code = 200
         mock_get.return_value.text = parent_pom
-        
+        mock_get.return_value.content = parent_pom.encode('utf-8')
+
         with zipfile.ZipFile(jar_path, 'w') as zf:
             zf.writestr("META-INF/maven/org.springframework.boot/my-app/pom.xml", child_pom)
-        
+
         extractor = JavaExtractor(registry_mode=True)
         metadata = extractor.extract(str(jar_path))
-        
+
         assert metadata.name == "org.springframework.boot:my-app"
         assert mock_get.called
+        # The parent POM is the only source of a description here
+        assert metadata.description == "Parent POM for Spring Boot"
+        assert metadata.provenance['description'].startswith('parent_pom:')
+
+    @patch('requests.get')
+    def test_parent_pom_failure_keeps_local_metadata(self, mock_get, tmp_path):
+        """A registry failure must not discard what the archive itself declared."""
+        jar_path = tmp_path / "child.jar"
+
+        child_pom = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>example-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>my-app</artifactId>
+    <version>3.2.1</version>
+    <description>Declared locally</description>
+</project>"""
+
+        mock_get.side_effect = requests.Timeout("rate limited")
+
+        with zipfile.ZipFile(jar_path, 'w') as zf:
+            zf.writestr("META-INF/maven/com.example/my-app/pom.xml", child_pom)
+
+        metadata = JavaExtractor(registry_mode=True).extract(str(jar_path))
+
+        assert metadata.name == "com.example:my-app"
+        assert metadata.description == "Declared locally"
 
 
 class TestExtractorAutoDetection:

--- a/tests/unit/test_java_hash_resolution.py
+++ b/tests/unit/test_java_hash_resolution.py
@@ -333,6 +333,49 @@ class TestHashResolutionFailures:
 
         assert len(registry.search_calls) == 1
 
+    def test_unreadable_search_body_is_not_a_miss(self, tmp_path, monkeypatch):
+        """A garbled 200 says nothing about the hash, so it must not be cached."""
+        jar_path = make_jar(tmp_path / "okhttp.jar")
+
+        garbled = FakeMavenCentral(docs=["not a document"])
+        monkeypatch.setattr(requests, 'get', garbled)
+        assert JavaExtractor(registry_mode=True).extract(jar_path).name == "unknown"
+
+        recovered = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', recovered)
+        metadata = JavaExtractor(registry_mode=True).extract(jar_path)
+
+        assert metadata.name == "com.squareup.okhttp3:okhttp"
+        assert len(recovered.search_calls) == 1
+
+    def test_incomplete_coordinates_are_skipped(self, tmp_path, monkeypatch):
+        registry = okhttp_registry(docs=[
+            {'a': 'missing-group', 'v': '1.0.0', 'p': 'jar'},
+            {'g': 'com.squareup.okhttp3', 'a': 'okhttp', 'v': '4.11.0', 'p': 'jar'},
+        ])
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor(registry_mode=True).extract(make_jar(tmp_path / "okhttp.jar"))
+
+        assert metadata.name == "com.squareup.okhttp3:okhttp"
+
+    def test_unreadable_pom_body_is_not_cached(self, tmp_path, monkeypatch):
+        """A 200 carrying an error page must not stick as the POM for a version."""
+        jar_path = make_jar(tmp_path / "okhttp.jar")
+
+        broken = okhttp_registry(poms={'okhttp-4.11.0.pom': '<html>503 from a proxy</html>'})
+        monkeypatch.setattr(requests, 'get', broken)
+        first = JavaExtractor(registry_mode=True).extract(jar_path)
+        # Coordinates still resolve; only the POM was unusable
+        assert first.name == "com.squareup.okhttp3:okhttp"
+        assert first.licenses == []
+
+        recovered = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', recovered)
+        metadata = JavaExtractor(registry_mode=True).extract(jar_path)
+
+        assert [lic.spdx_id for lic in metadata.licenses] == ["Apache-2.0"]
+
     def test_missing_pom_still_yields_coordinates(self, tmp_path, monkeypatch):
         registry = okhttp_registry(poms={})
         monkeypatch.setattr(requests, 'get', registry)

--- a/tests/unit/test_java_hash_resolution.py
+++ b/tests/unit/test_java_hash_resolution.py
@@ -1,0 +1,384 @@
+"""Tests for resolving Maven coordinates from a file hash."""
+
+import zipfile
+
+import pytest
+import requests
+
+from upmex.api import maven_central
+from upmex.extractors.java_extractor import JavaExtractor
+
+MANIFEST_WITHOUT_COORDINATES = (
+    "Manifest-Version: 1.0\n"
+    "Automatic-Module-Name: okhttp3\n"
+)
+
+OKHTTP_POM = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <groupId>com.squareup.okhttp3</groupId>
+    <artifactId>okhttp</artifactId>
+    <version>4.11.0</version>
+    <name>okhttp</name>
+    <description>Square’s meticulous HTTP client for Java and Kotlin.</description>
+    <url>https://square.github.io/okhttp/</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Square, Inc.</name>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/square/okhttp</url>
+    </scm>
+</project>"""
+
+POM_WITH_PARENT = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>example-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>shaded-lib</artifactId>
+    <version>2.3.4</version>
+</project>"""
+
+PARENT_POM = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <groupId>com.example</groupId>
+    <artifactId>example-parent</artifactId>
+    <version>1.0.0</version>
+    <licenses>
+        <license>
+            <name>MIT</name>
+        </license>
+    </licenses>
+</project>"""
+
+
+class FakeResponse:
+    """Minimal stand-in for a requests response."""
+
+    def __init__(self, status_code=200, text='', payload=None):
+        self.status_code = status_code
+        self.content = text.encode('utf-8')
+        # Maven Central serves POMs with no charset, so requests falls back to
+        # ISO-8859-1 for .text. Mirroring that keeps a decoding regression visible.
+        self.text = self.content.decode('iso-8859-1')
+        self._payload = payload
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("response is not JSON")
+        return self._payload
+
+
+class FakeMavenCentral:
+    """Routes requests.get calls to canned search index and POM responses."""
+
+    def __init__(self, docs=None, num_found=None, poms=None, error=None):
+        self.docs = docs if docs is not None else []
+        self.num_found = num_found if num_found is not None else len(self.docs)
+        self.poms = poms or {}
+        self.error = error
+        self.search_calls = []
+        self.pom_calls = []
+
+    def __call__(self, url, params=None, timeout=None, headers=None):
+        if 'solrsearch' in url:
+            self.search_calls.append(params)
+            if self.error:
+                raise self.error
+            return FakeResponse(payload={
+                'response': {'numFound': self.num_found, 'docs': self.docs}
+            })
+
+        self.pom_calls.append(url)
+        for suffix, text in self.poms.items():
+            if url.endswith(suffix):
+                return FakeResponse(text=text)
+        return FakeResponse(status_code=404)
+
+
+def make_jar(path, manifest=MANIFEST_WITHOUT_COORDINATES, extra_files=None):
+    """Build a jar with no POM, optionally with extra archive members."""
+    with zipfile.ZipFile(path, 'w') as zf:
+        zf.writestr('META-INF/MANIFEST.MF', manifest)
+        zf.writestr('okhttp3/OkHttpClient.class', b'\xca\xfe\xba\xbe')
+        for name, content in (extra_files or {}).items():
+            zf.writestr(name, content)
+    return str(path)
+
+
+def okhttp_registry(**kwargs):
+    """A registry that resolves the okhttp jar hash and serves its POM."""
+    defaults = {
+        'docs': [{
+            'id': 'com.squareup.okhttp3:okhttp:4.11.0',
+            'g': 'com.squareup.okhttp3',
+            'a': 'okhttp',
+            'v': '4.11.0',
+            'p': 'jar',
+        }],
+        'poms': {'okhttp-4.11.0.pom': OKHTTP_POM},
+    }
+    defaults.update(kwargs)
+    return FakeMavenCentral(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def clear_lookup_caches():
+    """Keep the process-wide lookup caches from leaking between tests."""
+    maven_central.clear_caches()
+    yield
+    maven_central.clear_caches()
+
+
+class TestHashResolutionGating:
+    """Coordinate resolution must not disturb the offline path."""
+
+    def test_no_lookup_without_registry_mode(self, tmp_path, monkeypatch):
+        registry = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor().extract(make_jar(tmp_path / "okhttp.jar"))
+
+        assert registry.search_calls == []
+        assert registry.pom_calls == []
+        assert metadata.name == "unknown"
+
+    def test_no_lookup_when_pom_is_present(self, tmp_path, monkeypatch):
+        registry = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', registry)
+
+        jar_path = tmp_path / "with-pom.jar"
+        with zipfile.ZipFile(jar_path, 'w') as zf:
+            zf.writestr("META-INF/maven/com.squareup.okhttp3/okhttp/pom.xml", OKHTTP_POM)
+
+        metadata = JavaExtractor(registry_mode=True).extract(str(jar_path))
+
+        assert registry.search_calls == []
+        assert metadata.name == "com.squareup.okhttp3:okhttp"
+
+
+class TestHashResolution:
+    """Resolving coordinates and licences for an archive with no POM."""
+
+    def test_resolves_coordinates_and_license(self, tmp_path, monkeypatch):
+        registry = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor(registry_mode=True).extract(make_jar(tmp_path / "okhttp.jar"))
+
+        assert metadata.name == "com.squareup.okhttp3:okhttp"
+        assert metadata.version == "4.11.0"
+        assert metadata.repository == "https://github.com/square/okhttp"
+        assert [lic.spdx_id for lic in metadata.licenses] == ["Apache-2.0"]
+        assert [author['name'] for author in metadata.authors] == ["Square, Inc."]
+
+    def test_pom_is_decoded_by_its_xml_declaration(self, tmp_path, monkeypatch):
+        registry = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor(registry_mode=True).extract(make_jar(tmp_path / "okhttp.jar"))
+
+        assert metadata.description == "Square’s meticulous HTTP client for Java and Kotlin."
+
+    def test_searches_by_the_artifact_sha1(self, tmp_path, monkeypatch):
+        registry = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', registry)
+
+        extractor = JavaExtractor(registry_mode=True)
+        jar_path = make_jar(tmp_path / "okhttp.jar")
+        extractor.extract(jar_path)
+
+        assert registry.search_calls == [{
+            'q': f'1:"{extractor.file_sha1(jar_path)}"',
+            'rows': maven_central.SEARCH_ROWS,
+            'wt': 'json',
+        }]
+
+    def test_records_resolution_source(self, tmp_path, monkeypatch):
+        registry = okhttp_registry(num_found=2)
+        monkeypatch.setattr(requests, 'get', registry)
+
+        extractor = JavaExtractor(registry_mode=True)
+        jar_path = make_jar(tmp_path / "okhttp.jar")
+        metadata = extractor.extract(jar_path)
+
+        assert metadata.provenance['name'].startswith('maven_central_hash:')
+        assert metadata.provenance['version'].startswith('maven_central_hash:')
+        assert metadata.provenance['licenses'] == (
+            "maven_central_pom:https://repo1.maven.org/maven2/com/squareup/okhttp3"
+            "/okhttp/4.11.0/okhttp-4.11.0.pom"
+        )
+
+        enrichment = metadata.enrichment[0]
+        assert enrichment.source == "maven_central"
+        assert enrichment.source_type == "registry"
+        assert enrichment.data['resolved_by'] == 'file_hash'
+        assert enrichment.data['sha1'] == extractor.file_sha1(jar_path)
+        # Ambiguous matches stay visible to a consumer
+        assert enrichment.data['match_count'] == 2
+        assert 'name' in enrichment.applied_fields
+        assert 'licenses' in enrichment.applied_fields
+
+    def test_prefers_a_jar_among_ambiguous_matches(self, tmp_path, monkeypatch):
+        registry = okhttp_registry(docs=[
+            {'g': 'com.example', 'a': 'relocated', 'v': '1.0.0', 'p': 'bundle'},
+            {'g': 'com.squareup.okhttp3', 'a': 'okhttp', 'v': '4.11.0', 'p': 'jar'},
+        ])
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor(registry_mode=True).extract(make_jar(tmp_path / "okhttp.jar"))
+
+        assert metadata.name == "com.squareup.okhttp3:okhttp"
+
+    def test_falls_through_to_the_parent_pom(self, tmp_path, monkeypatch):
+        registry = FakeMavenCentral(
+            docs=[{'g': 'com.example', 'a': 'shaded-lib', 'v': '2.3.4', 'p': 'jar'}],
+            poms={
+                'shaded-lib-2.3.4.pom': POM_WITH_PARENT,
+                'example-parent-1.0.0.pom': PARENT_POM,
+            }
+        )
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor(registry_mode=True).extract(make_jar(tmp_path / "shaded.jar"))
+
+        assert metadata.name == "com.example:shaded-lib"
+        assert [lic.spdx_id for lic in metadata.licenses] == ["MIT"]
+        assert metadata.provenance['licenses'].startswith('parent_pom:')
+        assert len(registry.pom_calls) == 2
+
+    def test_local_license_file_is_not_overwritten(self, tmp_path, monkeypatch):
+        registry = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', registry)
+
+        jar_path = make_jar(
+            tmp_path / "okhttp.jar",
+            extra_files={'META-INF/LICENSE': 'License: MIT\n'}
+        )
+        metadata = JavaExtractor(registry_mode=True).extract(jar_path)
+
+        # Coordinates still resolve, but the locally declared licence wins
+        assert metadata.name == "com.squareup.okhttp3:okhttp"
+        assert [lic.spdx_id for lic in metadata.licenses] == ["MIT"]
+        assert 'licenses' not in metadata.provenance
+
+    def test_caches_lookups_across_extractions(self, tmp_path, monkeypatch):
+        registry = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', registry)
+
+        jar_path = make_jar(tmp_path / "okhttp.jar")
+        JavaExtractor(registry_mode=True).extract(jar_path)
+        JavaExtractor(registry_mode=True).extract(jar_path)
+
+        assert len(registry.search_calls) == 1
+        assert len(registry.pom_calls) == 1
+
+
+class TestHashResolutionFailures:
+    """Every lookup failure leaves the local metadata untouched."""
+
+    def test_unknown_hash(self, tmp_path, monkeypatch):
+        registry = FakeMavenCentral(docs=[])
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor(registry_mode=True).extract(make_jar(tmp_path / "private.jar"))
+
+        assert metadata.name == "unknown"
+        assert metadata.licenses == []
+        assert len(registry.search_calls) == 1
+        assert registry.pom_calls == []
+
+    def test_search_timeout(self, tmp_path, monkeypatch):
+        registry = okhttp_registry(error=requests.Timeout("rate limited"))
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor(registry_mode=True).extract(make_jar(tmp_path / "okhttp.jar"))
+
+        assert metadata.name == "unknown"
+        assert metadata.enrichment == []
+
+    def test_unknown_hash_is_cached_but_a_failure_is_not(self, tmp_path, monkeypatch):
+        """A rate limit says nothing about the artifact, so it must not stick."""
+        jar_path = make_jar(tmp_path / "okhttp.jar")
+
+        failing = okhttp_registry(error=requests.Timeout("rate limited"))
+        monkeypatch.setattr(requests, 'get', failing)
+        assert JavaExtractor(registry_mode=True).extract(jar_path).name == "unknown"
+
+        # The same hash resolves once the rate limit lifts
+        recovered = okhttp_registry()
+        monkeypatch.setattr(requests, 'get', recovered)
+        metadata = JavaExtractor(registry_mode=True).extract(jar_path)
+
+        assert metadata.name == "com.squareup.okhttp3:okhttp"
+        assert len(recovered.search_calls) == 1
+
+    def test_definitive_miss_is_not_retried(self, tmp_path, monkeypatch):
+        registry = FakeMavenCentral(docs=[])
+        monkeypatch.setattr(requests, 'get', registry)
+
+        jar_path = make_jar(tmp_path / "private.jar")
+        JavaExtractor(registry_mode=True).extract(jar_path)
+        JavaExtractor(registry_mode=True).extract(jar_path)
+
+        assert len(registry.search_calls) == 1
+
+    def test_missing_pom_still_yields_coordinates(self, tmp_path, monkeypatch):
+        registry = okhttp_registry(poms={})
+        monkeypatch.setattr(requests, 'get', registry)
+
+        metadata = JavaExtractor(registry_mode=True).extract(make_jar(tmp_path / "okhttp.jar"))
+
+        assert metadata.name == "com.squareup.okhttp3:okhttp"
+        assert metadata.version == "4.11.0"
+        assert metadata.licenses == []
+        assert metadata.enrichment[0].applied_fields == ['name', 'version']
+
+
+class TestDeclaredPomLicenses:
+    """A POM declares its licence as prose, which osslili cannot always classify."""
+
+    def test_license_url_resolves_a_prose_name(self, tmp_path):
+        jar_path = tmp_path / "with-pom.jar"
+        with zipfile.ZipFile(jar_path, 'w') as zf:
+            zf.writestr("META-INF/maven/com.squareup.okhttp3/okhttp/pom.xml", OKHTTP_POM)
+
+        metadata = JavaExtractor().extract(str(jar_path))
+
+        # "The Apache Software License, Version 2.0" is unclassifiable on its own;
+        # the declared URL identifies it.
+        assert [lic.spdx_id for lic in metadata.licenses] == ["Apache-2.0"]
+
+    def test_unclassifiable_declaration_is_kept(self, tmp_path):
+        pom = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <groupId>com.example</groupId>
+    <artifactId>vendor-lib</artifactId>
+    <version>1.0.0</version>
+    <licenses>
+        <license>
+            <name>Example Corp Commercial License</name>
+        </license>
+    </licenses>
+</project>"""
+        jar_path = tmp_path / "vendor.jar"
+        with zipfile.ZipFile(jar_path, 'w') as zf:
+            zf.writestr("META-INF/maven/com.example/vendor-lib/pom.xml", pom)
+
+        metadata = JavaExtractor().extract(str(jar_path))
+
+        assert len(metadata.licenses) == 1
+        declared = metadata.licenses[0]
+        assert declared.name == "Example Corp Commercial License"
+        assert declared.detection_method == "declared"
+        assert declared.file_path == "pom.xml"


### PR DESCRIPTION
Closes #91.

## Problem

`JavaExtractor` recovers an inherited licence by following `<parent>` and fetching the parent POM in registry mode. That covers a jar whose POM is present but whose `<licenses>` are inherited. It cannot help a jar that carries **no POM at all** — there is no `<parent>` to follow and no coordinates to look one up by. Shaded, relocated and repackaged artifacts extracted as `name: "unknown"` with no version and no licence.

Two things stood in the way that the issue did not anticipate:

- The whole registry block lived inside `_extract_maven_metadata`, so the `MANIFEST.MF` fallback branch had **no enrichment call site at all**.
- `file_hash` is assigned in `PackageExtractor.extract` *after* the extractor runs, and the consumer that raised this calls `JavaExtractor().extract(...)` directly, so the hash has to be computed inside the extractor.

## Approach

```
no META-INF/**/pom.xml
  └─ local licence files (META-INF/LICENSE …)        unchanged, still win
       └─ sha1(jar) → Maven Central index → coordinates
            └─ published POM → licence + project metadata
                 └─ still no licence? → existing <parent> hop
```

New `upmex.api.maven_central.MavenCentralAPI` joins the other registry and API clients. `_fetch_parent_pom` is split into fetch, parse and apply steps so the parent hop and the hash-resolved path share one implementation.

- Runs **only** when the archive has no POM and only in registry mode — the offline path makes no requests
- Locally declared data always wins; only empty or `NO-ASSERTION` fields are filled
- Lookups cached by hash for the process lifetime, so a re-scan costs one request
- `provenance` records `maven_central_hash:` / `maven_central_pom:` per field, and the enrichment record carries the sha1, coordinates, `match_count` and `resolved_by: file_hash`
- An ambiguous hash (a republished or relocated artifact) prefers a `jar` among the matches and reports the total rather than hiding it

## Result

Verified live against the artifact from the issue, `okhttp-4.11.0.jar` (sha1 `436932d695b2c43f2c86b8111c596179cd133d56`, no POM inside):

| | before | after |
|---|---|---|
| name | `unknown` | `com.squareup.okhttp3:okhttp` |
| version | – | `4.11.0` |
| licence | – | `Apache-2.0` (exact, 1.0) |
| purl | – | `pkg:maven/com/squareup/okhttp3/okhttp@4.11.0` |
| repository | – | `https://github.com/square/okhttp` |
| copyright | – | `Copyright Square, Inc.` |

## Fixes needed along the way

- **POM licences were dropped when unclassifiable.** `The Apache Software License, Version 2.0` — the string in okhttp's POM and the most common spelling in the ecosystem — is not something `osslili` can classify, so without this the feature resolved coordinates and still returned no licence. The declared `<url>` is now tried as a second signal, and a declaration that still cannot be classified is recorded verbatim with `detection_method="declared"`, mirroring the npm fix in 1.6.8. This also fixes the embedded-POM path.
- **Non-ASCII POM text was mangled.** Maven Central serves POMs with no charset, so requests fell back to ISO-8859-1 (`Square’s` → `Squareâs`). POMs are parsed from raw bytes so the XML declaration decides.
- **Registry failures discarded local metadata.** An error fetching a parent POM propagated out of POM parsing, silently downgrading a fully described package to the no-POM path.
- **Enrichment records were not serializable.** The parent-POM record held `LicenseInfo` objects, breaking JSON output whenever a parent supplied the licence.
- **Failed lookups were cached as misses.** A rate-limit timeout was remembered as "hash not found" for the rest of the run; only definitive answers are cached now.

## Tests

170 passed, 2 skipped. 17 new tests in `tests/unit/test_java_hash_resolution.py`, all offline: gating in both directions, resolution and provenance, ambiguous matches, the parent fall-through, local licence precedence, caching, and every failure mode (unknown hash, timeout, missing POM, transient-vs-definitive caching).

`test_maven_parent_pom_fetch` is also strengthened — its mock set `.text` while the code read `.content`, so the parse always failed silently and the assertion only checked that a request happened.

## Note

`search.maven.org` rate-limits hard; read timeouts arrive within seconds of a successful query. Degradation is clean — valid output, metadata untouched, retried on the next run. `central.sonatype.com` is not an alternative: its solrsearch returns no results for hash queries.

Version bumped to 1.6.9 in `pyproject.toml` and `src/upmex/__init__.py` with a CHANGELOG entry, per the release process in CONTRIBUTING.