### PR TITLE
fix(nuget): stop dropping and crashing on declared licences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **NuGet licences are no longer dropped or crashed on** (closes #100). A `.nuspec` can declare its licence four ways and only one of them worked:
+  - An SPDX expression `osslili` cannot classify, such as `LicenseRef-Proprietary`, was discarded. It is now recorded verbatim with `detection_method="declared"`, as the npm and Maven paths already do.
+  - A compound expression reported only its first identifier, so `MIT OR Apache-2.0` became `MIT`, which states something the package does not. Compound expressions are now kept whole.
+  - `<license type="file">` stored the filename and never read it, even though the file ships inside the package. It is now read, including nested paths and Windows separators.
+  - `licenseUrl` only recognised `opensource.org/licenses/`, missing `licenses.nuget.org/<expression>`, which is the form NuGet itself generates.
+  - Two paths passed a list where a single licence was expected and raised `AttributeError`. A package shipping a recognisable `LICENSE` file with no `<license>` element failed extraction outright, since that error propagated out of `extract()`.
+- **Conan packages no longer fail to extract on Python 3.12 and later** (closes #101): `ConanExtractor` branched on `ast.Str`, which was removed in that release, and the error propagated out of `extract()` rather than being contained, so a scan over a directory stopped at the first Conan artifact. The branch was already redundant, since `ast.Constant` covers string literals on every supported version. No test exercised Conan extraction; one now does.
+- **The text output labelled the SHA-1 as SHA256.** The value was always the SHA-1, matching `file_info.hashes.sha1` in the JSON output; only the label was wrong.
+
 ## [1.7.0] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.7.1] - 2026-08-11
 
 ### Fixed
 - **NuGet licences are no longer dropped or crashed on** (closes #100). A `.nuspec` can declare its licence four ways and only one of them worked:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "upmex"
-version = "1.7.0"
+version = "1.7.1"
 description = "Universal Package Metadata Extractor - Extract metadata from various package formats"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/upmex/__init__.py
+++ b/src/upmex/__init__.py
@@ -1,6 +1,6 @@
 """UPMEX - Universal Package Metadata Extractor."""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 __author__ = "Oscar Valenzuela B."
 __email__ = "oscar.valenzuela.b@gmail.com"
 

--- a/src/upmex/extractors/conan_extractor.py
+++ b/src/upmex/extractors/conan_extractor.py
@@ -179,10 +179,10 @@ class ConanExtractor(BaseExtractor):
         Returns:
             Extracted value
         """
+        # ast.Constant covers every literal on the Python versions upmex supports.
+        # The ast.Str alias it replaced was removed in Python 3.12.
         if isinstance(node, ast.Constant):
             return node.value
-        elif isinstance(node, ast.Str):
-            return node.s
         elif isinstance(node, ast.List):
             return [self._extract_value(elt, content) for elt in node.elts]
         elif isinstance(node, ast.Tuple):

--- a/src/upmex/extractors/nuget_extractor.py
+++ b/src/upmex/extractors/nuget_extractor.py
@@ -41,38 +41,16 @@ class NuGetExtractor(BaseExtractor):
         try:
             with zipfile.ZipFile(package_path, 'r') as zip_file:
                 nuspec_file = None
-                license_files = []
-                
-                # Find .nuspec file and LICENSE files
+
                 for file_info in zip_file.namelist():
                     if file_info.endswith('.nuspec'):
                         nuspec_file = file_info
-                    elif 'LICENSE' in file_info.upper() or 'LICENCE' in file_info.upper():
-                        license_files.append(file_info)
-                
+                        break
+
                 if nuspec_file:
                     # Parse .nuspec XML file
                     nuspec_content = zip_file.read(nuspec_file)
-                    self._parse_nuspec(nuspec_content, metadata)
-                
-                # Try to detect license from LICENSE files if not found in nuspec
-                if not metadata.licenses and license_files:
-                    for license_file in license_files:
-                        license_content = zip_file.read(license_file).decode('utf-8', errors='ignore')
-                        license_info = self.detect_licenses_from_text(
-                            license_content,
-                            filename=license_file
-                        )
-                        if license_info:
-                            from ..core.models import LicenseInfo, LicenseConfidenceLevel
-                            metadata.licenses.append(LicenseInfo(
-                                spdx_id=license_info.spdx_id,
-                                confidence=license_info.confidence,
-                                confidence_level=LicenseConfidenceLevel(license_info.confidence_level),
-                                detection_method=license_info.detection_method,
-                                file_path=license_info.file_path
-                            ))
-                            break
+                    self._parse_nuspec(nuspec_content, metadata, package_path)
 
         except Exception as e:
             logger.error(f"Error extracting NuGet metadata: {e}")
@@ -80,12 +58,14 @@ class NuGetExtractor(BaseExtractor):
 
         return metadata
 
-    def _parse_nuspec(self, nuspec_content: bytes, metadata: PackageMetadata) -> None:
+    def _parse_nuspec(self, nuspec_content: bytes, metadata: PackageMetadata,
+                      package_path: str) -> None:
         """Parse .nuspec XML content and populate metadata.
-        
+
         Args:
             nuspec_content: XML content of .nuspec file
             metadata: PackageMetadata object to populate
+            package_path: Path to the .nupkg, for reading files it references
         """
         try:
             root = ET.fromstring(nuspec_content)
@@ -157,56 +137,35 @@ class NuGetExtractor(BaseExtractor):
                 if license_elem is not None:
                     license_type = license_elem.get('type', 'expression')
                     if license_type == 'expression':
-                        # SPDX expression
-                        license_text = license_elem.text
-                        if license_text:
-                            # Format license text for better osslili detection
-                            if len(license_text) < 20 and ':' not in license_text:
-                                formatted_text = f"License: {license_text}"
-                            else:
-                                formatted_text = license_text
-                            license_infos = self.detect_licenses_from_text(
-                                formatted_text,
-                                filename='.nuspec'
-                            )
-                            if license_infos:
-                                metadata.licenses.extend(license_infos)
+                        self._record_declared_license(
+                            metadata, license_elem.text, source='.nuspec'
+                        )
                     elif license_type == 'file':
-                        # License is in a file
+                        # The named file ships inside the package, so read it
                         license_file = license_elem.text
                         if license_file:
                             metadata.raw_metadata['license_file'] = license_file
-                
+                            self._detect_license_from_packaged_file(
+                                metadata, package_path, license_file
+                            )
+
                 # Fallback to licenseUrl for older packages
                 if not metadata.licenses:
                     license_url = self._get_text(metadata_elem, 'licenseUrl', namespaces)
                     if license_url:
-                        # Try to detect license from URL
-                        if 'opensource.org/licenses/' in license_url.lower():
-                            # Extract license ID from URL
-                            parts = license_url.split('/')
-                            if parts:
-                                license_id = parts[-1].upper()
-                                # Format license text for better osslili detection
-                                if len(license_id) < 20 and ':' not in license_id:
-                                    formatted_text = f"License: {license_id}"
-                                else:
-                                    formatted_text = license_id
-                                license_info = self.detect_licenses_from_text(
-                                    formatted_text,
-                                    filename='licenseUrl'
-                                )
-                                if license_info:
-                                    from ..core.models import LicenseInfo, LicenseConfidenceLevel
-                                    metadata.licenses.append(LicenseInfo(
-                                        spdx_id=license_info.spdx_id,
-                                        confidence=license_info.confidence,
-                                        confidence_level=LicenseConfidenceLevel(license_info.confidence_level),
-                                        detection_method=license_info.detection_method,
-                                        file_path='licenseUrl'
-                                    ))
+                        license_id = self._license_id_from_url(license_url)
+                        if license_id:
+                            self._record_declared_license(
+                                metadata, license_id, source='licenseUrl'
+                            )
                         metadata.raw_metadata['license_url'] = license_url
-                
+
+                # Last resort: a licence file shipped without being declared
+                if not metadata.licenses:
+                    detected = self.find_and_detect_licenses(archive_path=str(package_path))
+                    if detected:
+                        metadata.licenses.extend(detected)
+
                 # Extract dependencies
                 dependencies_elem = metadata_elem.find(f'{ns_prefix}dependencies', namespaces)
                 if dependencies_elem is None:
@@ -256,6 +215,135 @@ class NuGetExtractor(BaseExtractor):
         except ET.ParseError as e:
             logger.error(f"Error parsing nuspec XML: {e}")
             raise
+
+    def _record_declared_license(self, metadata: PackageMetadata,
+                                 declared: Optional[str], source: str) -> None:
+        """Record a licence a .nuspec declares.
+
+        A NuGet ``<license type="expression">`` holds an SPDX expression, which is
+        authoritative even when osslili cannot classify it. ``LicenseRef-`` values
+        and compound expressions are both valid and both undetectable as licence
+        *text*, so the declared value is kept verbatim rather than dropped. This
+        matches how the npm extractor treats its declared field.
+
+        Args:
+            metadata: Metadata to append to
+            declared: The declared expression, may be None or empty
+            source: Where it was declared, recorded as the licence's file path
+        """
+        if not declared:
+            return
+
+        declared = declared.strip()
+        if not declared:
+            return
+
+        # A compound expression is a single statement about the licensing, and
+        # osslili reports only the first identifier it recognises. Reporting one
+        # arm of "MIT OR Apache-2.0" would change its meaning, so keep it whole.
+        if self._is_compound_expression(declared):
+            from ..core.models import LicenseInfo, LicenseConfidenceLevel
+            metadata.licenses.append(LicenseInfo(
+                spdx_id=declared,
+                name=declared,
+                confidence=1.0,
+                confidence_level=LicenseConfidenceLevel.HIGH,
+                detection_method='declared',
+                file_path=source
+            ))
+            return
+
+        # Format short values so osslili recognises them as a licence tag
+        if len(declared) < 20 and ':' not in declared:
+            formatted_text = f"License: {declared}"
+        else:
+            formatted_text = declared
+
+        detected = self.detect_licenses_from_text(formatted_text, filename=source)
+        if detected:
+            for info in detected:
+                info.file_path = source
+            metadata.licenses.extend(detected)
+            return
+
+        # osslili produced nothing, so keep what the package declared
+        from ..core.models import LicenseInfo, LicenseConfidenceLevel
+        metadata.licenses.append(LicenseInfo(
+            spdx_id=declared,
+            name=declared,
+            confidence=1.0,
+            confidence_level=LicenseConfidenceLevel.HIGH,
+            detection_method='declared',
+            file_path=source
+        ))
+
+    @staticmethod
+    def _is_compound_expression(declared: str) -> bool:
+        """Check whether a declared licence combines several identifiers.
+
+        Args:
+            declared: The declared SPDX expression
+
+        Returns:
+            True if it uses an SPDX operator
+        """
+        tokens = declared.replace('(', ' ').replace(')', ' ').split()
+        return any(token.upper() in ('OR', 'AND', 'WITH') for token in tokens)
+
+    def _detect_license_from_packaged_file(self, metadata: PackageMetadata,
+                                           package_path: str, license_file: str) -> None:
+        """Detect a licence from a file the .nuspec points at.
+
+        ``<license type="file">`` names a file shipped inside the package, so the
+        text is available without a network lookup.
+
+        Args:
+            metadata: Metadata to append to
+            package_path: Path to the .nupkg
+            license_file: Path of the licence file within the package
+        """
+        try:
+            with zipfile.ZipFile(package_path, 'r') as zip_file:
+                # The nuspec may use either separator, and may name a nested path
+                wanted = license_file.replace('\\', '/').lstrip('./')
+                match = next(
+                    (n for n in zip_file.namelist()
+                     if n.replace('\\', '/') == wanted or n.endswith('/' + wanted)),
+                    None
+                )
+                if not match:
+                    return
+
+                text = zip_file.read(match).decode('utf-8', errors='ignore')
+
+            detected = self.detect_licenses_from_text(text, filename=license_file)
+            for info in detected:
+                info.file_path = license_file
+            metadata.licenses.extend(detected)
+        except Exception as e:
+            logger.error(f"Error reading declared license file '{license_file}': {e}")
+
+    def _license_id_from_url(self, license_url: str) -> Optional[str]:
+        """Recover a licence identifier from a licenseUrl.
+
+        Older packages declare only a URL. NuGet's own canonical form is
+        ``https://licenses.nuget.org/<expression>``; ``opensource.org/licenses/<id>``
+        is the other common one.
+
+        Args:
+            license_url: The declared URL
+
+        Returns:
+            The identifier, or None if the URL is not one we can read
+        """
+        lowered = license_url.lower()
+        for marker in ('licenses.nuget.org/', 'opensource.org/licenses/'):
+            position = lowered.find(marker)
+            if position != -1:
+                # Everything after the marker, so a bare host URL yields nothing
+                identifier = license_url[position + len(marker):].strip('/')
+                return identifier or None
+        return None
 
     def _parse_dependencies(self, dependencies_elem, metadata: PackageMetadata, namespaces: dict) -> None:
         """Parse dependencies from nuspec.

--- a/src/upmex/utils/output_formatter.py
+++ b/src/upmex/utils/output_formatter.py
@@ -138,7 +138,7 @@ class OutputFormatter:
             lines.append(f"File Size: {metadata.file_size:,} bytes")
         
         if metadata.file_hash:
-            lines.append(f"SHA256: {metadata.file_hash}")
+            lines.append(f"SHA1: {metadata.file_hash}")
         
         lines.append(f"Schema Version: {metadata.schema_version}")
 

--- a/tests/unit/test_conan_extractor.py
+++ b/tests/unit/test_conan_extractor.py
@@ -1,0 +1,76 @@
+"""Tests for the Conan extractor.
+
+The AST walk over conanfile.py is version sensitive: it used ast.Str, which was
+removed in Python 3.12, and nothing exercised it, so extraction raised on every
+Conan package on current Python.
+"""
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from upmex.core.extractor import PackageExtractor
+from upmex.core.models import PackageType
+from upmex.extractors.conan_extractor import ConanExtractor
+
+CONANFILE = '''from conan import ConanFile
+
+class FmtConan(ConanFile):
+    name = "fmt"
+    version = "10.2.1"
+    license = "MIT"
+    author = "Example Author"
+    url = "https://github.com/fmtlib/fmt"
+    homepage = "https://fmt.dev"
+    description = "A formatting library"
+    topics = ("formatting", "logging", "cpp")
+'''
+
+
+def make_conan_tgz(path, conanfile=CONANFILE):
+    """Build a Conan package archive holding a conanfile.py."""
+    with tarfile.open(path, 'w:gz') as tar:
+        data = conanfile.encode('utf-8')
+        info = tarfile.TarInfo(name='conanfile.py')
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return str(path)
+
+
+class TestConanExtraction:
+
+    def test_conanfile_py_is_parsed(self, tmp_path):
+        """Regression guard: this raised AttributeError on Python 3.12 and later."""
+        metadata = PackageExtractor().extract(make_conan_tgz(tmp_path / "fmt.tgz"))
+
+        assert metadata.package_type == PackageType.CONAN
+        assert metadata.name == "fmt"
+        assert metadata.version == "10.2.1"
+        assert [lic.spdx_id for lic in metadata.licenses] == ["MIT"]
+        assert metadata.homepage == "https://fmt.dev"
+        assert metadata.repository == "https://github.com/fmtlib/fmt"
+        assert "formatting" in metadata.keywords
+
+    def test_string_values_survive_the_ast_walk(self, tmp_path):
+        """String literals parse as ast.Constant on every supported version."""
+        extractor = ConanExtractor()
+        import ast
+
+        tree = ast.parse(CONANFILE)
+        values = extractor._extract_from_ast(tree, CONANFILE)
+
+        assert values['name'] == "fmt"
+        assert values['license'] == "MIT"
+        assert values['topics'] == ("formatting", "logging", "cpp")
+
+    def test_extraction_does_not_raise_on_a_real_package(self):
+        package = Path('test-packages/fmt-10.2.1.tgz')
+        if not package.exists():
+            pytest.skip("fmt-10.2.1.tgz is not available")
+
+        metadata = PackageExtractor().extract(str(package))
+
+        assert metadata.name == "fmt"
+        assert metadata.version == "10.2.1"

--- a/tests/unit/test_nuget_licenses.py
+++ b/tests/unit/test_nuget_licenses.py
@@ -1,0 +1,180 @@
+"""Tests for the ways a NuGet package can declare its licence.
+
+A .nuspec can state its licence as an SPDX expression, as a file shipped inside
+the package, or as a URL. Each is a separate path, and a package that declares a
+licence upmex cannot classify must not come back looking unlicensed.
+"""
+
+import zipfile
+
+import pytest
+
+from upmex.core.extractor import PackageExtractor
+from upmex.extractors.nuget_extractor import NuGetExtractor
+
+MIT_TEXT = """MIT License
+
+Copyright (c) 2024 Example
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT."""
+
+
+def make_nupkg(path, license_xml='', extra_files=None):
+    """Build a .nupkg whose .nuspec differs only in its licence declaration."""
+    with zipfile.ZipFile(path, 'w') as zf:
+        zf.writestr("package.nuspec", f"""<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Example.Package</id>
+    <version>1.0.0</version>
+    <authors>Example</authors>
+    <description>A package</description>
+    {license_xml}
+  </metadata>
+</package>""")
+        for name, content in (extra_files or {}).items():
+            zf.writestr(name, content)
+    return str(path)
+
+
+def licenses_of(path):
+    return [(lic.spdx_id, lic.detection_method) for lic in
+            PackageExtractor().extract(path).licenses]
+
+
+class TestLicenseExpression:
+    """<license type="expression"> holds an SPDX expression."""
+
+    def test_recognised_identifier(self, tmp_path):
+        path = make_nupkg(tmp_path / "p.nupkg", '<license type="expression">MIT</license>')
+
+        assert licenses_of(path) == [("MIT", "osslili_tag")]
+
+    @pytest.mark.parametrize('expression', [
+        'MIT OR Apache-2.0',
+        'GPL-2.0-only WITH Classpath-exception-2.0',
+        'Apache-2.0 AND MIT',
+    ])
+    def test_compound_expression_is_kept_whole(self, tmp_path, expression):
+        """Reporting one arm of a compound expression would change its meaning."""
+        path = make_nupkg(tmp_path / "p.nupkg", f'<license type="expression">{expression}</license>')
+
+        assert licenses_of(path) == [(expression, "declared")]
+
+    def test_unclassifiable_expression_is_kept(self, tmp_path):
+        """A LicenseRef is a valid declaration that is not detectable as text."""
+        path = make_nupkg(tmp_path / "p.nupkg",
+                          '<license type="expression">LicenseRef-Proprietary</license>')
+
+        assert licenses_of(path) == [("LicenseRef-Proprietary", "declared")]
+
+    def test_empty_expression(self, tmp_path):
+        path = make_nupkg(tmp_path / "p.nupkg", '<license type="expression"></license>')
+
+        assert licenses_of(path) == []
+
+
+class TestLicenseFile:
+    """<license type="file"> names a file shipped inside the package."""
+
+    def test_file_is_read(self, tmp_path):
+        path = make_nupkg(tmp_path / "p.nupkg",
+                          '<license type="file">LICENSE.txt</license>',
+                          {"LICENSE.txt": MIT_TEXT})
+
+        assert [spdx for spdx, _ in licenses_of(path)] == ["MIT"]
+
+    def test_windows_separator_and_nested_path(self, tmp_path):
+        path = make_nupkg(tmp_path / "p.nupkg",
+                          '<license type="file">docs\\LICENSE.md</license>',
+                          {"docs/LICENSE.md": MIT_TEXT})
+
+        assert [spdx for spdx, _ in licenses_of(path)] == ["MIT"]
+
+    def test_declared_file_is_recorded_even_when_missing(self, tmp_path):
+        path = make_nupkg(tmp_path / "p.nupkg", '<license type="file">GONE.txt</license>')
+        metadata = PackageExtractor().extract(path)
+
+        assert metadata.licenses == []
+        assert metadata.raw_metadata['license_file'] == "GONE.txt"
+
+
+class TestLicenseUrl:
+    """Older packages declare only a licenseUrl."""
+
+    @pytest.mark.parametrize('url', [
+        'https://licenses.nuget.org/MIT',
+        'https://opensource.org/licenses/MIT',
+    ])
+    def test_identifier_is_recovered(self, tmp_path, url):
+        path = make_nupkg(tmp_path / "p.nupkg", f'<licenseUrl>{url}</licenseUrl>')
+
+        assert [spdx for spdx, _ in licenses_of(path)] == ["MIT"]
+
+    def test_unreadable_url_is_still_recorded(self, tmp_path):
+        path = make_nupkg(tmp_path / "p.nupkg",
+                          '<licenseUrl>https://example.com/eula</licenseUrl>')
+        metadata = PackageExtractor().extract(path)
+
+        assert metadata.licenses == []
+        assert metadata.raw_metadata['license_url'] == "https://example.com/eula"
+
+    @pytest.mark.parametrize('url,expected', [
+        ('https://licenses.nuget.org/MIT', 'MIT'),
+        ('https://licenses.nuget.org/Apache-2.0/', 'Apache-2.0'),
+        ('http://opensource.org/licenses/BSD-3-Clause', 'BSD-3-Clause'),
+        ('https://example.com/license', None),
+        ('https://licenses.nuget.org/', None),
+    ])
+    def test_url_parsing(self, url, expected):
+        assert NuGetExtractor()._license_id_from_url(url) == expected
+
+
+class TestUndeclaredLicense:
+    """A package may ship a licence file without pointing at it."""
+
+    def test_archive_is_scanned_as_a_last_resort(self, tmp_path):
+        path = make_nupkg(tmp_path / "p.nupkg", '', {"LICENSE.txt": MIT_TEXT})
+
+        assert [spdx for spdx, _ in licenses_of(path)] == ["MIT"]
+
+    def test_no_licence_anywhere(self, tmp_path):
+        """Absence is a valid answer and must not raise."""
+        path = make_nupkg(tmp_path / "p.nupkg")
+        metadata = PackageExtractor().extract(path)
+
+        assert metadata.licenses == []
+        assert metadata.name == "Example.Package"
+
+
+class TestRealPackages:
+    """The published packages kept in test-packages/ still extract."""
+
+    @pytest.mark.parametrize('filename,expected_name,expected_license', [
+        ('Newtonsoft.Json.13.0.3.nupkg', 'Newtonsoft.Json', 'MIT'),
+        ('Serilog.3.1.1.nupkg', 'Serilog', 'Apache-2.0'),
+    ])
+    def test_extraction(self, filename, expected_name, expected_license):
+        from pathlib import Path
+
+        package = Path('test-packages') / filename
+        if not package.exists():
+            pytest.skip(f"{filename} is not available")
+
+        metadata = PackageExtractor().extract(str(package))
+
+        assert metadata.name == expected_name
+        assert expected_license in [lic.spdx_id for lic in metadata.licenses]
+        assert metadata.purl == f"pkg:nuget/{expected_name}@{metadata.version}"


### PR DESCRIPTION
Closes #100 and #101. Found while writing the new documentation, by testing what the docs were about to claim.

## NuGet licences

A `.nuspec` can declare its licence four ways. One of them worked.

| Declaration | Before | After |
|---|---|---|
| `type="expression"` with an SPDX id | `MIT` | unchanged |
| `type="expression"` compound, `MIT OR Apache-2.0` | `MIT` only | `MIT OR Apache-2.0`, kept whole |
| `type="expression"` `LicenseRef-Proprietary` | no licence | recorded as `declared` |
| `type="file"` pointing at a packaged file | no licence | file is read |
| `licenseUrl` = `licenses.nuget.org/MIT` | no licence | `MIT` |
| `licenseUrl` = `opensource.org/licenses/MIT` | `AttributeError` | `MIT` |
| undeclared `LICENSE` file in the archive | `AttributeError`, extraction failed | `MIT` |

Two paths passed a list where one licence was expected. The last row is the worst case: that error propagated out of `extract()`, so a package shipping a recognisable `LICENSE` file with no `<license>` element failed outright rather than returning what it could.

The shape of these failures matters as much as the count. A proprietary package, or one that licenses by file, reported **no licence at all**. In a compliance report that reads as nothing to review, when it is precisely the case a human should look at.

Three of the four are the same bug class already fixed for npm in 1.6.8 and for Maven in 1.7.0: a declaration the detector cannot classify is discarded instead of recorded. NuGet never got that treatment. It now uses the same `detection_method="declared"` convention, so a consumer handling npm and Maven output already handles this.

Compound expressions are new ground. Reporting one arm of `MIT OR Apache-2.0` is not a partial answer, it is a different statement, so the expression is kept intact rather than resolved.

## Conan

`ConanExtractor._extract_value()` branched on `ast.Str`, removed in Python 3.12:

```python
>>> PackageExtractor().extract("fmt-10.2.1.tgz")
AttributeError: module 'ast' has no attribute 'ast.Str'
```

That is every Conan package on 3.12 and 3.13, both of which the project supports and CI runs. It also propagated out of `extract()`, so a loop over a directory died at the first Conan artifact instead of skipping it.

The branch was already redundant. `ast.Constant`, handled immediately above it, covers string literals on every version this project supports, and `ast.Str` has been an alias for it since 3.8. Removing it is the whole fix.

CI stayed green because nothing extracted a Conan package. `test-packages/fmt-10.2.1.tgz` has been in the repository the whole time, unused. There is now a test for it.

## Text output

`SHA256:` was printing the SHA-1. The value was always correct and matched `file_info.hashes.sha1` in the JSON; only the label was wrong. For a provenance tool a mislabelled hash is worth more than a typo fix, since anyone comparing that value against a published digest would use the wrong algorithm.

## Tests

222 passed, 2 skipped. 21 new NuGet cases covering one path per row of the table above, plus URL parsing edge cases and the two real packages in `test-packages/`. 3 new Conan cases, including a regression guard naming the Python version that broke it.

One of those tests caught a bug in the fix itself: a bare `https://licenses.nuget.org/` returned the hostname as the licence identifier. The parser now splits at the marker rather than taking the last path segment.