### PR TITLE
docs: serve pages at /commands/ rather than /commands.html

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,15 +31,20 @@ jobs:
         working-directory: docs
         run: bundle exec jekyll build --strict_front_matter --trace
 
-      - name: Check for broken internal links
+      - name: Check that internal links resolve in the built site
         working-directory: docs
         run: |
-          # Every page the navigation and the pages themselves point at must exist
+          # Checked against _site rather than the sources, so a link that points
+          # at a path the permalink style does not produce is caught too.
           missing=0
           for target in $(grep -rho '{{ site.baseurl }}/[a-z-]*/' *.md | sed 's|{{ site.baseurl }}/||; s|/$||' | sort -u); do
-            if [ ! -f "${target}.md" ]; then
-              echo "link target does not exist: ${target}.md"
+            if [ ! -f "_site/${target}/index.html" ] && [ ! -f "_site/${target}.html" ]; then
+              echo "link target is not in the built site: /${target}/"
               missing=1
             fi
           done
+
+          if [ $missing -eq 0 ]; then
+            echo "all internal links resolve"
+          fi
           exit $missing

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,9 @@ baseurl: /upmex
 
 remote_theme: just-the-docs/just-the-docs
 
+# Pages are linked as /commands/ rather than /commands.html
+permalink: pretty
+
 plugins:
   - jekyll-remote-theme
 


### PR DESCRIPTION
Follow-up to #103. The site published successfully but every internal link 404s.

## What happened

The pages link to each other as `/commands/`, `/api/` and so on, but Jekyll's default permalink style builds `commands.md` into a sibling `commands.html`. So the built site is correct and the links are correct, and they disagree:

```
https://semclone.github.io/upmex/            200
https://semclone.github.io/upmex/commands/   404
https://semclone.github.io/upmex/commands.html   200
```

`permalink: pretty` makes each page build to `commands/index.html`, which is the shape the links assume and the more conventional URL to publish.

## Why CI did not catch it

The link check I added in #103 verified that the *source* file existed:

```bash
if [ ! -f "${target}.md" ]; then
```

`commands.md` did exist, so it passed. Whether the link resolved was never the question it asked, which is the same mistake as documenting an API without running it.

It now checks the built output:

```bash
if [ ! -f "_site/${target}/index.html" ] && [ ! -f "_site/${target}.html" ]; then
```

That fails if a link points at a path the permalink style does not produce, which is the actual failure mode.