### PR TITLE
chore: release 1.7.2 with the documentation URL fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.7.2] - 2026-08-11
 
 ### Changed
-- The `Documentation` project URL points at the published documentation site, `https://semclone.github.io/upmex/`, rather than the README anchor on GitHub. The site went up with the Jekyll rewrite and the metadata still sent readers to the README.
+- The `Documentation` project URL points at the published documentation site, `https://semclone.github.io/upmex/`, rather than the README anchor on GitHub. The site went up with the Jekyll rewrite and the metadata still sent readers to the README. The stale "Complete project documentation" link in the README's Support section pointed at the repository root and now points at the site too, and `SUPPORT.md` leads with it rather than with the `docs/` folder.
 
 ## [1.7.1] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-08-11
+
+### Changed
+- The `Documentation` project URL points at the published documentation site, `https://semclone.github.io/upmex/`, rather than the README anchor on GitHub. The site went up with the Jekyll rewrite and the metadata still sent readers to the README.
+
 ## [1.7.1] - 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for deta
 
 For support and questions:
 - [GitHub Issues](https://github.com/SemClone/upmex/issues) - Bug reports and feature requests
-- [Documentation](https://github.com/SemClone/upmex) - Complete project documentation
+- [Documentation](https://semclone.github.io/upmex/) - Complete project documentation
 - [SEMCL.ONE Community](https://semcl.one) - Ecosystem support and discussions
 
 ## License

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,9 +6,9 @@ Thank you for using this project! Here are the best ways to get help:
 
 ### Documentation
 
+- Read the full documentation at [semclone.github.io/upmex](https://semclone.github.io/upmex/)
 - Check the [README](README.md) for basic usage and setup instructions
 - Review the [CONTRIBUTING](CONTRIBUTING.md) guide for development setup
-- Look through existing documentation in the `/docs` folder (if available)
 
 ### Getting Answers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "upmex"
-version = "1.7.1"
+version = "1.7.2"
 description = "Universal Package Metadata Extractor - Extract metadata from various package formats"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -68,7 +68,7 @@ upmex = "upmex.cli:main"
 Homepage = "https://github.com/SemClone/upmex"
 Repository = "https://github.com/SemClone/upmex"
 Issues = "https://github.com/SemClone/upmex/issues"
-Documentation = "https://github.com/SemClone/upmex#readme"
+Documentation = "https://semclone.github.io/upmex/"
 Changelog = "https://github.com/SemClone/upmex/blob/main/CHANGELOG.md"
 
 [tool.setuptools.packages.find]

--- a/src/upmex/__init__.py
+++ b/src/upmex/__init__.py
@@ -1,6 +1,6 @@
 """UPMEX - Universal Package Metadata Extractor."""
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 __author__ = "Oscar Valenzuela B."
 __email__ = "oscar.valenzuela.b@gmail.com"
 


### PR DESCRIPTION
The `Documentation` entry in `[project.urls]` still pointed at `https://github.com/SemClone/upmex#readme`, so the PyPI sidebar sent readers to the README anchor rather than to the documentation site published at https://semclone.github.io/upmex/ (#103, #104). It now points at the site, which returns 200.

Patch release so the corrected metadata reaches PyPI: version bumped to 1.7.2 in `pyproject.toml` and `src/upmex/__init__.py`, with a CHANGELOG entry. No code changes.