### PR TITLE
Say how a licence was found, and how sure that makes us

### DIFF
--- a/src/upmex/cli.py
+++ b/src/upmex/cli.py
@@ -246,10 +246,7 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
                                     'can_extract': lambda self, path: False
                                 })()
 
-                                license_infos = temp_extractor.detect_licenses_from_text(
-                                    license_str,
-                                    filename='ecosystems_api'
-                                )
+                                license_infos = temp_extractor.detect_licenses_from_declared_name(license_str, 'ecosystems_api')
                                 if license_infos:
                                     metadata.licenses.extend(license_infos)
                                     applied_fields.append('licenses')
@@ -320,10 +317,7 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
                                 'can_extract': lambda self, path: False
                             })()
 
-                            license_infos = temp_extractor.detect_licenses_from_text(
-                                purldb_metadata['license_expression'],
-                                filename='purldb_api'
-                            )
+                            license_infos = temp_extractor.detect_licenses_from_declared_name(purldb_metadata['license_expression'], 'purldb_api')
                             if license_infos:
                                 metadata.licenses.extend(license_infos)
                                 applied_fields.append('licenses')

--- a/src/upmex/core/extractor.py
+++ b/src/upmex/core/extractor.py
@@ -204,10 +204,7 @@ class PackageExtractor:
                             'can_extract': lambda self, path: False
                         })()
                         
-                        license_infos = temp_extractor.detect_licenses_from_text(
-                            license_str,
-                            filename='ecosystems_api'
-                        )
+                        license_infos = temp_extractor.detect_licenses_from_declared_name(license_str, 'ecosystems_api')
                         if license_infos:
                             metadata.licenses.extend(license_infos)
                 

--- a/src/upmex/core/models.py
+++ b/src/upmex/core/models.py
@@ -84,6 +84,11 @@ class LicenseInfo:
     confidence_level: LicenseConfidenceLevel = LicenseConfidenceLevel.NONE
     detection_method: Optional[str] = None
     file_path: Optional[str] = None
+    # How the detector classified this, carried through so a consumer can tell
+    # a licence the package declares from one a scan merely recognised, and
+    # can find the file that said so.
+    category: Optional[str] = None
+    match_type: Optional[str] = None
 
 
 @dataclass
@@ -161,6 +166,12 @@ class PackageMetadata:
                         "confidence_level": lic.confidence_level.value,
                         "source": lic.detection_method,
                         "file": lic.file_path,
+                        # Carried into the output too. Without these a
+                        # consumer reads an identifier and a number and cannot
+                        # tell a licence the package declares from one a scan
+                        # recognised in a file that mentions it.
+                        "category": lic.category,
+                        "match_type": lic.match_type,
                     } for lic in self.licenses
                 ],
             },

--- a/src/upmex/extractors/base.py
+++ b/src/upmex/extractors/base.py
@@ -5,6 +5,11 @@ import os
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any, List, Union
 from pathlib import Path
+import re
+
+# An SPDX expression joining licences. Resolving one of these to a single
+# identifier reports one arm as though it were the whole statement.
+_COMPOUND_EXPRESSION = re.compile(r"\s(?:OR|AND|WITH)\s", re.IGNORECASE)
 
 from ..core.models import (
     PackageMetadata,
@@ -96,6 +101,74 @@ class BaseExtractor(ABC):
         except Exception:
             return None
 
+    def detect_licenses_from_declared_name(
+        self,
+        declared: str,
+        source_file: Optional[str] = None,
+    ) -> List[LicenseInfo]:
+        """Resolve a licence name a package declares into SPDX identifiers.
+
+        Packages declare a name, not a licence text: "BSD License" in a PyPI
+        classifier, "MIT" in a package.json. Resolving that to an identifier
+        is worth doing, and it is an inference rather than a reading.
+
+        This existed as the same block copied into nine extractors: wrap the
+        name in "License: ..." and hand the result to the text detector. The
+        detector then reported an SPDX identifier at confidence 1.0, level
+        exact, method tag, from a file that does not exist, because the
+        document it read was one we had just written. For packaging, whose
+        classifier says "BSD License", that produced BSD-3-Clause as an exact
+        finding when BSD names four licences and the project uses the
+        two-clause one.
+
+        So the answer is kept and labelled for what it is. Where the declared
+        name is already the identifier, resolving it is identity and stays
+        exact; where it is a family or a prose name, the identifier is the
+        detector's best reading of it and says so.
+        """
+        if not declared:
+            return []
+
+        # A compound expression names a relationship between licences, and
+        # resolving it would report one arm as though it were the whole:
+        # "MIT OR Apache-2.0" is a choice, and "MIT" alone is a different
+        # statement. Kept verbatim, which is what the SPDX expression already
+        # is.
+        if _COMPOUND_EXPRESSION.search(declared):
+            return [
+                LicenseInfo(
+                    name=declared.strip(),
+                    spdx_id=declared.strip(),
+                    confidence=1.0,
+                    confidence_level=LicenseConfidenceLevel.EXACT,
+                    detection_method="declared_expression",
+                    match_type="declared_expression",
+                    category="declared",
+                    file_path=source_file,
+                )
+            ]
+
+        # osslili reads a licence declaration more reliably with the prefix,
+        # unless the value already looks like a document or a expression.
+        if len(declared) < 20 and ':' not in declared:
+            text = f"License: {declared}"
+        else:
+            text = declared
+
+        resolved = self.detect_licenses_from_text(text, source_file)
+        for license_info in resolved:
+            identifier = (license_info.spdx_id or "").strip().lower()
+            verbatim = declared.strip().lower()
+            license_info.detection_method = "declared_name"
+            license_info.match_type = "declared_name"
+            license_info.category = "declared"
+            license_info.file_path = source_file
+            if identifier != verbatim:
+                # The name was interpreted. Exact would say the file named
+                # this identifier, and it named something else.
+                license_info.confidence_level = LicenseConfidenceLevel.HIGH
+        return resolved
+
     def detect_licenses_from_text(self,
                                  text: str,
                                  filename: Optional[str] = None) -> List[LicenseInfo]:
@@ -125,7 +198,13 @@ class BaseExtractor(ABC):
                 confidence_level=LicenseConfidenceLevel(
                     license_dict.get('confidence_level', 'low')
                 ),
-                detection_method=license_dict.get('source', 'osslili')
+                detection_method=license_dict.get('source', 'osslili'),
+                # Carried so a consumer can check the claim against the file
+                # that made it. It was dropped here, which is why every
+                # licence upmex reported came back with file_path None.
+                file_path=license_dict.get('file'),
+                category=license_dict.get('category'),
+                match_type=license_dict.get('match_type'),
             )
             licenses.append(license_info)
 

--- a/src/upmex/extractors/cocoapods_extractor.py
+++ b/src/upmex/extractors/cocoapods_extractor.py
@@ -309,12 +309,7 @@ class CocoaPodsExtractor(BaseExtractor):
                 license_type = license_data.get('type')
                 license_file = license_data.get('file')
                 if license_type:
-                    # Format license text for better osslili detection
-                    if len(license_type) < 20 and ':' not in license_type:
-                        formatted_text = f"License: {license_type}"
-                    else:
-                        formatted_text = license_type
-                    detected = self.detect_licenses_from_text(formatted_text)
+                    detected = self.detect_licenses_from_declared_name(license_type, '*.podspec.json')
                     if detected:
                         licenses.extend(detected)
                 elif license_file:
@@ -330,12 +325,7 @@ class CocoaPodsExtractor(BaseExtractor):
                         except Exception:
                             pass
             elif isinstance(license_data, str):
-                # Format license text for better osslili detection
-                if len(license_data) < 20 and ':' not in license_data:
-                    formatted_text = f"License: {license_data}"
-                else:
-                    formatted_text = license_data
-                detected = self.detect_licenses_from_text(formatted_text)
+                detected = self.detect_licenses_from_declared_name(license_data, '*.podspec.json')
                 if detected:
                     licenses.extend(detected)
         

--- a/src/upmex/extractors/conda_extractor.py
+++ b/src/upmex/extractors/conda_extractor.py
@@ -280,12 +280,7 @@ class CondaExtractor(BaseExtractor):
         licenses = []
         license_info = index_json.get('license') or (recipe.get('about', {}).get('license') if recipe else None)
         if license_info:
-            # Format license text for better osslili detection
-            if len(license_info) < 20 and ':' not in license_info:
-                formatted_text = f"License: {license_info}"
-            else:
-                formatted_text = license_info
-            detected = self.detect_licenses_from_text(formatted_text)
+            detected = self.detect_licenses_from_declared_name(license_info, 'info/index.json')
             if detected:
                 licenses.extend(detected)
         

--- a/src/upmex/extractors/gradle_extractor.py
+++ b/src/upmex/extractors/gradle_extractor.py
@@ -272,15 +272,7 @@ class GradleExtractor(BaseExtractor):
             match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
             if match:
                 license_text = match.group(1)
-                # Format license text for better osslili detection
-                if len(license_text) < 20 and ':' not in license_text:
-                    formatted_text = f"License: {license_text}"
-                else:
-                    formatted_text = license_text
-                return self.detect_licenses_from_text(
-                    formatted_text,
-                    filename='build.gradle'
-                )
+                return self.detect_licenses_from_declared_name(license_text, 'build.gradle')
         
         return None
     

--- a/src/upmex/extractors/npm_extractor.py
+++ b/src/upmex/extractors/npm_extractor.py
@@ -204,12 +204,7 @@ class NpmExtractor(BaseExtractor):
         not detectable license *text* — we fall back to recording the declared
         value verbatim rather than dropping it.
         """
-        # Format license text for better osslili detection.
-        if len(declared) < 20 and ':' not in declared:
-            formatted_text = f"License: {declared}"
-        else:
-            formatted_text = declared
-        detected = self.detect_licenses_from_text(formatted_text, 'package.json')
+        detected = self.detect_licenses_from_declared_name(declared, 'package.json')
         if detected:
             metadata.licenses.extend(detected)
             return

--- a/src/upmex/extractors/nuget_extractor.py
+++ b/src/upmex/extractors/nuget_extractor.py
@@ -253,16 +253,8 @@ class NuGetExtractor(BaseExtractor):
             ))
             return
 
-        # Format short values so osslili recognises them as a licence tag
-        if len(declared) < 20 and ':' not in declared:
-            formatted_text = f"License: {declared}"
-        else:
-            formatted_text = declared
-
-        detected = self.detect_licenses_from_text(formatted_text, filename=source)
+        detected = self.detect_licenses_from_declared_name(declared, source)
         if detected:
-            for info in detected:
-                info.file_path = source
             metadata.licenses.extend(detected)
             return
 

--- a/src/upmex/extractors/python_extractor.py
+++ b/src/upmex/extractors/python_extractor.py
@@ -185,12 +185,7 @@ class PythonExtractor(BaseExtractor):
             # Detect license from text
             license_text = msg.get('License')
             if license_text:
-                # Format license text for better osslili detection
-                if len(license_text) < 20 and ':' not in license_text:
-                    formatted_text = f"License: {license_text}"
-                else:
-                    formatted_text = license_text
-                detected = self.detect_licenses_from_text(formatted_text, 'METADATA')
+                detected = self.detect_licenses_from_declared_name(license_text, 'METADATA')
                 if detected:
                     metadata.licenses.extend(detected)
             
@@ -202,12 +197,7 @@ class PythonExtractor(BaseExtractor):
                         license_parts = classifier.split(' :: ')
                         if len(license_parts) > 1:
                             license_name = license_parts[-1]
-                            # Format license text for better osslili detection
-                            if len(license_name) < 20 and ':' not in license_name:
-                                formatted_text = f"License: {license_name}"
-                            else:
-                                formatted_text = license_name
-                            detected = self.detect_licenses_from_text(formatted_text, 'METADATA')
+                            detected = self.detect_licenses_from_declared_name(license_name, 'METADATA')
                             if detected:
                                 metadata.licenses.extend(detected)
                                 break

--- a/src/upmex/extractors/ruby_extractor.py
+++ b/src/upmex/extractors/ruby_extractor.py
@@ -159,16 +159,7 @@ class RubyExtractor(BaseExtractor):
                         
                         if license_text:
                             # Format license text for better osslili detection
-                            # If it's just a short license identifier, add "License:" prefix
-                            if len(license_text) < 20 and not ':' in license_text:
-                                formatted_text = f"License: {license_text}"
-                            else:
-                                formatted_text = license_text
-                            
-                            license_infos = self.detect_licenses_from_text(
-                                formatted_text, 
-                                filename='metadata.gz'
-                            )
+                            license_infos = self.detect_licenses_from_declared_name(license_text, 'metadata.gz')
                             if license_infos:
                                 metadata.licenses.extend(license_infos)
                         

--- a/src/upmex/extractors/rust_extractor.py
+++ b/src/upmex/extractors/rust_extractor.py
@@ -126,15 +126,7 @@ class RustExtractor(BaseExtractor):
                         # Extract license
                         if package.get('license'):
                             license_text = package['license']
-                            # Format license text for better osslili detection
-                            if len(license_text) < 20 and ':' not in license_text:
-                                formatted_text = f"License: {license_text}"
-                            else:
-                                formatted_text = license_text
-                            license_infos = self.detect_licenses_from_text(
-                                formatted_text,
-                                filename='Cargo.toml'
-                            )
+                            license_infos = self.detect_licenses_from_declared_name(license_text, 'Cargo.toml')
                             if license_infos:
                                 metadata.licenses.extend(license_infos)
                         

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -72,13 +72,29 @@ class OssliliSubprocessDetector:
                                 for lic in scan_result['license_evidence']:
                                     # Map detected_license to spdx_id for consistency
                                     spdx_id = lic.get('detected_license', lic.get('spdx_id', 'Unknown'))
+                                    # osslili reports the file it read, the
+                                    # category it assigned and how it matched.
+                                    # Overwriting "file" with the path we were
+                                    # handed threw away the only way to check
+                                    # the claim, and for a synthesised
+                                    # document that path is a name we invented.
                                     license_info = {
                                         "name": lic.get('name', spdx_id),
                                         "spdx_id": spdx_id,
                                         "confidence": lic.get('confidence', 0.0),
-                                        "confidence_level": self._get_confidence_level(lic.get('confidence', 0.0)),
+                                        "confidence_level": self._get_confidence_level(
+                                            lic.get('confidence', 0.0),
+                                            lic.get('detection_method', ''),
+                                            lic.get('match_type', ''),
+                                        ),
                                         "source": f"osslili_{lic.get('detection_method', 'unknown')}",
+                                        # The content was written to a temp
+                                        # file for osslili, so its "file" is
+                                        # that path. The name the caller asked
+                                        # about is the real one.
                                         "file": file_path,
+                                        "category": lic.get('category'),
+                                        "match_type": lic.get('match_type'),
                                     }
                                     
                                     # Include high-confidence matches or tag detections
@@ -98,9 +114,19 @@ class OssliliSubprocessDetector:
                                         "name": lic.get('name', lic.get('spdx_id', 'Unknown')),
                                         "spdx_id": lic.get('spdx_id', 'Unknown'),
                                         "confidence": lic.get('confidence', 0.0),
-                                        "confidence_level": self._get_confidence_level(lic.get('confidence', 0.0)),
+                                        "confidence_level": self._get_confidence_level(
+                                            lic.get('confidence', 0.0),
+                                            lic.get('detection_method', ''),
+                                            lic.get('match_type', ''),
+                                        ),
                                         "source": f"osslili_{lic.get('detection_method', 'unknown')}",
+                                        # The content was written to a temp
+                                        # file for osslili, so its "file" is
+                                        # that path. The name the caller asked
+                                        # about is the real one.
                                         "file": file_path,
+                                        "category": lic.get('category'),
+                                        "match_type": lic.get('match_type'),
                                     }
                                     
                                     # Include high-confidence matches or tag detections
@@ -183,9 +209,17 @@ class OssliliSubprocessDetector:
                                     "name": lic.get('name', spdx_id),
                                     "spdx_id": spdx_id,
                                     "confidence": lic.get('confidence', 0.0),
-                                    "confidence_level": self._get_confidence_level(lic.get('confidence', 0.0)),
+                                    "confidence_level": self._get_confidence_level(
+                                        lic.get('confidence', 0.0),
+                                        lic.get('detection_method', ''),
+                                        lic.get('match_type', ''),
+                                    ),
                                     "source": f"osslili_{lic.get('detection_method', 'unknown')}",
+                                    # Scanning a directory, so this really is
+                                    # the file osslili read.
                                     "file": lic.get('file', 'unknown'),
+                                    "category": lic.get('category'),
+                                    "match_type": lic.get('match_type'),
                                 }
                                 
                                 # Include high-confidence matches or tag detections
@@ -211,9 +245,15 @@ class OssliliSubprocessDetector:
                                     "name": lic.get('name', lic.get('spdx_id', 'Unknown')),
                                     "spdx_id": lic.get('spdx_id', 'Unknown'),
                                     "confidence": lic.get('confidence', 0.0),
-                                    "confidence_level": self._get_confidence_level(lic.get('confidence', 0.0)),
+                                    "confidence_level": self._get_confidence_level(
+                                        lic.get('confidence', 0.0),
+                                        lic.get('detection_method', ''),
+                                        lic.get('match_type', ''),
+                                    ),
                                     "source": f"osslili_{lic.get('detection_method', 'unknown')}",
                                     "file": lic.get('source_file', 'unknown'),
+                                    "category": lic.get('category'),
+                                    "match_type": lic.get('match_type'),
                                 }
                                 
                                 # Only include very high-confidence matches
@@ -257,13 +297,28 @@ class OssliliSubprocessDetector:
             
         return {"licenses": licenses, "copyrights": copyrights}
 
-    def _get_confidence_level(self, confidence: float) -> str:
-        """Convert numeric confidence to level string."""
-        if confidence >= 0.95:
+    # A match is exact when the file says which licence it is, not when a
+    # similarity score is close to one. osslili reports which of those it did.
+    EXACT_METHODS = frozenset({"tag", "spdx_identifier"})
+
+    def _get_confidence_level(
+        self,
+        confidence: float,
+        detection_method: str = "",
+        match_type: str = "",
+    ) -> str:
+        """How far this is from certain.
+
+        Exact means the text names the licence: an SPDX identifier or a
+        licence tag. A similarity score does not become exact by being high,
+        and calling 0.988 exact told a consumer that packaging's BSD-2-Clause
+        had been read off a declaration when it had been matched against one.
+        """
+        if detection_method in self.EXACT_METHODS or match_type in self.EXACT_METHODS:
             return "exact"
-        elif confidence >= 0.85:
+        if confidence >= 0.95:
             return "high"
-        elif confidence >= 0.70:
+        elif confidence >= 0.85:
             return "medium"
         else:
             return "low"

--- a/tests/integration/test_license_extraction.py
+++ b/tests/integration/test_license_extraction.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 
 from upmex.core.extractor import PackageExtractor
+from upmex.core.models import LicenseConfidenceLevel
 from upmex.extractors.python_extractor import PythonExtractor
 from upmex.extractors.npm_extractor import NpmExtractor
 from upmex.extractors.java_extractor import JavaExtractor
@@ -39,7 +40,15 @@ Classifier: License :: OSI Approved :: MIT License
         assert len(metadata.licenses) > 0
         assert metadata.licenses[0].spdx_id == "MIT"
         assert metadata.licenses[0].confidence >= 0.6
-        assert metadata.licenses[0].detection_method in ["osslili_tag", "regex_field", "regex_pattern"]
+        # The wheel declares "License: MIT" in its METADATA, so this is a name
+        # the package stated rather than a licence text that was read.
+        assert metadata.licenses[0].detection_method in [
+            "declared_name", "osslili_tag", "regex_field", "regex_pattern"
+        ]
+        assert metadata.licenses[0].file_path == "METADATA"
+        # "MIT" is already the identifier, so resolving it is identity and the
+        # match stays exact. A family name like "BSD License" would not.
+        assert metadata.licenses[0].confidence_level == LicenseConfidenceLevel.EXACT
     
     def test_npm_package_license_extraction(self, tmp_path):
         """Test extracting license from NPM package."""
@@ -112,8 +121,13 @@ Classifier: License :: OSI Approved :: Apache Software License
         
         # Should detect at least one license
         assert len(metadata.licenses) > 0
-        # First detected should be from the License field
-        assert metadata.licenses[0].spdx_id in ["MIT", "Apache-2.0"]
+        # The declaration is a choice between two licences, and reporting one
+        # arm of it says something the package did not: a consumer that may
+        # not use Apache-2.0 needs to see that MIT is on offer, and one that
+        # may not use MIT needs the same the other way. The expression is what
+        # was declared, so the expression is what is reported.
+        assert metadata.licenses[0].spdx_id == "MIT OR Apache-2.0"
+        assert metadata.licenses[0].detection_method == "declared_expression"
     
     def test_spdx_identifier_extraction(self, tmp_path):
         """Test extracting SPDX-License-Identifier."""

--- a/tests/unit/test_license_provenance.py
+++ b/tests/unit/test_license_provenance.py
@@ -1,0 +1,396 @@
+"""What a reported licence is, and where it came from.
+
+Every licence upmex reported came back with `file_path` None and, if its
+confidence was at least 0.95, `confidence_level` exact. Both were untrue in
+ways a consumer could not detect.
+
+A similarity score of 0.988 is a very good match against a licence text. It is
+not a reading of a declaration, and calling it exact told a consumer the file
+had named that licence. Separately, nine extractors resolved a declared name
+by writing "License: {name}" to a file and handing it to the text detector,
+which then reported an SPDX identifier at confidence 1.0 from a document we
+had just written: packaging's classifier says "BSD License", and that produced
+BSD-3-Clause as an exact finding for a project that uses the two-clause one.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from upmex.core.models import LicenseConfidenceLevel
+from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector
+
+
+def evidence(**overrides):
+    """One osslili evidence record, in the shape the CLI emits."""
+    record = {
+        "file": "/tmp/whatever/LICENSE",
+        "detected_license": "Apache-2.0",
+        "confidence": 1.0,
+        "detection_method": "tag",
+        "category": "declared",
+        "match_type": "spdx_identifier",
+        "description": "SPDX-License-Identifier: Apache-2.0 found",
+    }
+    record.update(overrides)
+    return record
+
+
+def run_with(records):
+    """Run the detector against a canned osslili response."""
+    payload = json.dumps({"scan_results": [{"license_evidence": records}]})
+
+    class Result:
+        returncode = 0
+        stdout = payload
+        stderr = ""
+
+    with patch("subprocess.run", return_value=Result()):
+        return OssliliSubprocessDetector().detect_from_file(
+            "LICENSE.txt", content="anything"
+        )
+
+
+class TestExactMeansTheFileNamedIt:
+    def test_a_tag_match_is_exact(self):
+        found = run_with([evidence(detection_method="tag", confidence=1.0)])
+
+        assert found[0]["confidence_level"] == "exact"
+
+    def test_an_spdx_identifier_match_is_exact(self):
+        found = run_with([
+            evidence(detection_method="regex", match_type="spdx_identifier")
+        ])
+
+        assert found[0]["confidence_level"] == "exact"
+
+    @pytest.mark.parametrize("confidence", [0.999, 0.989, 0.988, 0.95])
+    def test_a_similarity_match_never_is(self, confidence):
+        """However close, it is a match against a licence rather than a
+        reading of one. 0.988 is where packaging's BSD-2-Clause lands."""
+        found = run_with([
+            evidence(
+                detection_method="dice-sorensen",
+                match_type="text_similarity",
+                confidence=confidence,
+            )
+        ])
+
+        assert found[0]["confidence_level"] == "high"
+
+    @pytest.mark.parametrize(
+        "confidence,level",
+        [(0.96, "high"), (0.90, "medium"), (0.5, "low")],
+    )
+    def test_a_weaker_similarity_is_weaker_still(self, confidence, level):
+        """Tested on the mapping directly: anything below 0.95 is filtered out
+        before it reaches a result, so the lower rungs are not reachable end
+        to end through this detector."""
+        detector = OssliliSubprocessDetector()
+
+        assert detector._get_confidence_level(
+            confidence, "dice-sorensen", "text_similarity"
+        ) == level
+
+    def test_the_method_beats_the_number_in_both_directions(self):
+        """A tag match at a low score is still a reading of a declaration."""
+        detector = OssliliSubprocessDetector()
+
+        assert detector._get_confidence_level(0.4, "tag", "") == "exact"
+        assert detector._get_confidence_level(1.0, "dice-sorensen", "") == "high"
+
+
+class TestTheClaimCanBeChecked:
+    def test_the_category_is_carried(self):
+        found = run_with([evidence(category="detected")])
+
+        assert found[0]["category"] == "detected"
+
+    def test_the_match_type_is_carried(self):
+        found = run_with([evidence(match_type="text_similarity")])
+
+        assert found[0]["match_type"] == "text_similarity"
+
+    def test_the_file_asked_about_is_reported_not_the_temp_copy(self):
+        """The content is written to a temp file for osslili, so the path it
+        reports is that copy. The name the caller asked about is the real one,
+        and reporting the temp path is how file_path came back useless."""
+        found = run_with([evidence(file="/var/folders/xx/tmpabc123.txt")])
+
+        assert found[0]["file"] == "LICENSE.txt"
+
+    def test_a_directory_scan_reports_the_file_osslili_read(self):
+        """There the path is real, and it is the only provenance there is."""
+        payload = json.dumps({
+            "scan_results": [{
+                "license_evidence": [evidence(file="/repo/LICENSE.APACHE")],
+                "copyright_evidence": [],
+            }]
+        })
+
+        class Result:
+            returncode = 0
+            stdout = payload
+            stderr = ""
+
+        with patch("subprocess.run", return_value=Result()):
+            found = OssliliSubprocessDetector().detect_from_directory("/repo")
+
+        assert found["licenses"][0]["file"] == "/repo/LICENSE.APACHE"
+
+
+class TestADeclaredNameIsResolvedNotRead:
+    """Nine extractors wrote "License: {name}" to a file and asked the text
+    detector what it said. Whatever came back was reported as a tag match at
+    confidence 1.0 from a filename we invented."""
+
+    def _resolve(self, declared, source_file="METADATA"):
+        from upmex.extractors.python_extractor import PythonExtractor
+
+        return PythonExtractor().detect_licenses_from_declared_name(
+            declared, source_file
+        )
+
+    def test_a_family_name_resolves_but_is_not_exact(self):
+        """BSD names four licences. Choosing one of them is an inference."""
+        resolved = self._resolve("BSD License")
+
+        assert resolved
+        assert resolved[0].confidence_level == LicenseConfidenceLevel.HIGH
+
+    def test_the_identifier_is_still_reported(self):
+        """Downgrading the certainty must not throw the answer away."""
+        resolved = self._resolve("BSD License")
+
+        assert resolved[0].spdx_id == "BSD-3-Clause"
+
+    def test_a_name_that_is_already_the_identifier_stays_exact(self):
+        """Resolving "MIT" to MIT is identity, not interpretation."""
+        resolved = self._resolve("MIT")
+
+        assert resolved[0].spdx_id == "MIT"
+        assert resolved[0].confidence_level == LicenseConfidenceLevel.EXACT
+
+    def test_it_says_the_name_was_declared_rather_than_the_text_read(self):
+        resolved = self._resolve("BSD License")
+
+        assert resolved[0].detection_method == "declared_name"
+        assert resolved[0].match_type == "declared_name"
+        assert resolved[0].category == "declared"
+
+    def test_it_points_at_the_file_that_declared_it(self):
+        """Not at the temporary document that was written to ask the question."""
+        resolved = self._resolve("BSD License", "METADATA")
+
+        assert resolved[0].file_path == "METADATA"
+
+    def test_nothing_declared_resolves_to_nothing(self):
+        assert self._resolve("") == []
+
+
+class TestItSurvivesIntoTheReportedLicence:
+    """The detector carries the provenance; the extractor that builds the
+    LicenseInfo has to keep it. It was dropped there, which is why every
+    licence upmex reported had file_path None however well the detector knew.
+    """
+
+    def _detect(self, records):
+        from upmex.extractors.python_extractor import PythonExtractor
+
+        payload = json.dumps({"scan_results": [{"license_evidence": records}]})
+
+        class Result:
+            returncode = 0
+            stdout = payload
+            stderr = ""
+
+        with patch("subprocess.run", return_value=Result()):
+            return PythonExtractor().detect_licenses_from_text(
+                "anything", "LICENSE.txt"
+            )
+
+    def test_the_file_reaches_the_licence(self):
+        found = self._detect([evidence()])
+
+        assert found[0].file_path == "LICENSE.txt"
+
+    def test_the_category_reaches_the_licence(self):
+        found = self._detect([evidence(category="detected")])
+
+        assert found[0].category == "detected"
+
+    def test_the_match_type_reaches_the_licence(self):
+        found = self._detect([
+            evidence(
+                match_type="text_similarity",
+                detection_method="dice-sorensen",
+                confidence=0.99,
+            )
+        ])
+
+        assert found[0].match_type == "text_similarity"
+
+    def test_the_level_reaches_the_licence(self):
+        found = self._detect([
+            evidence(
+                match_type="text_similarity",
+                detection_method="dice-sorensen",
+                confidence=0.99,
+            )
+        ])
+
+        assert found[0].confidence_level == LicenseConfidenceLevel.HIGH
+
+
+class TestADeclaredNameWithNoFileToPointAt:
+    """Several extractors resolve a name they read from a structure rather
+    than a named file. Naming a file there would be inventing one."""
+
+    def test_no_source_file_means_no_file_path(self):
+        from upmex.extractors.python_extractor import PythonExtractor
+
+        resolved = PythonExtractor().detect_licenses_from_declared_name("MIT", None)
+
+        assert resolved
+        assert resolved[0].file_path is None
+
+    def test_it_is_not_the_placeholder_the_detector_uses(self):
+        """The text detector calls an unnamed document "content", and
+        reporting that as the file it came from would be a fiction."""
+        from upmex.extractors.python_extractor import PythonExtractor
+
+        resolved = PythonExtractor().detect_licenses_from_declared_name("MIT", None)
+
+        assert resolved[0].file_path != "content"
+
+
+class TestACompoundExpressionIsAStatement:
+    """"MIT OR Apache-2.0" is a choice the package offers. Reporting one arm
+    says something the package did not: a consumer who may not use Apache-2.0
+    needs to see MIT is on offer, and the other way round.
+    """
+
+    def _resolve(self, declared):
+        from upmex.extractors.python_extractor import PythonExtractor
+
+        return PythonExtractor().detect_licenses_from_declared_name(declared, "META")
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "MIT OR Apache-2.0",
+            "Apache-2.0 AND MIT",
+            "GPL-2.0-only WITH Classpath-exception-2.0",
+            "MIT or Apache-2.0",
+        ],
+    )
+    def test_it_is_kept_whole(self, expression):
+        resolved = self._resolve(expression)
+
+        assert len(resolved) == 1
+        assert resolved[0].spdx_id == expression.strip()
+
+    def test_it_is_exact_because_it_is_what_was_written(self):
+        resolved = self._resolve("MIT OR Apache-2.0")
+
+        assert resolved[0].confidence_level == LicenseConfidenceLevel.EXACT
+        assert resolved[0].detection_method == "declared_expression"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "MIT",
+            "Standard ML of New Jersey",       # St-AND-ard
+            "Sun Industry Standards Source License",
+            "Vim",
+            "Nordic Widget Licence",
+        ],
+    )
+    def test_a_name_containing_the_letters_is_not_an_expression(self, name):
+        """The separator is a word on its own, not a substring.
+
+        Matched as a substring, "Standard" makes every licence with it in its
+        name read as a conjunction, and the whole name is then reported
+        verbatim as though it were an SPDX expression.
+        """
+        from upmex.extractors.base import _COMPOUND_EXPRESSION
+
+        assert _COMPOUND_EXPRESSION.search(name) is None, name
+
+    def test_a_resolvable_name_is_still_a_name(self):
+        resolved = self._resolve("MIT")
+
+        assert resolved[0].detection_method == "declared_name"
+
+
+class TestTheOutputCarriesItToo:
+    """Provenance that stops at the dataclass is provenance a consumer of the
+    JSON never sees."""
+
+    def _document(self, **license_fields):
+        from upmex.core.models import LicenseInfo, PackageMetadata, PackageType
+
+        metadata = PackageMetadata(name="p", version="1", package_type=PackageType.NPM)
+        metadata.licenses = [LicenseInfo(**license_fields)]
+        return metadata.to_dict()
+
+    def test_the_category_is_published(self):
+        document = self._document(
+            spdx_id="JSON", name="JSON", confidence=0.98,
+            confidence_level=LicenseConfidenceLevel.HIGH,
+            category="detected", match_type="text_similarity",
+        )
+
+        assert document["licensing"]["declared_licenses"][0]["category"] == "detected"
+
+    def test_the_match_type_is_published(self):
+        document = self._document(
+            spdx_id="JSON", name="JSON", confidence=0.98,
+            confidence_level=LicenseConfidenceLevel.HIGH,
+            category="detected", match_type="text_similarity",
+        )
+
+        assert document["licensing"]["declared_licenses"][0]["match_type"] == (
+            "text_similarity"
+        )
+
+    def test_a_declaration_and_a_recognition_are_distinguishable(self):
+        """Which is the whole point: same identifier, different standing."""
+        declared = self._document(
+            spdx_id="MIT", name="MIT", confidence=1.0,
+            confidence_level=LicenseConfidenceLevel.EXACT,
+            category="declared", match_type="spdx_identifier",
+        )["licensing"]["declared_licenses"][0]
+        recognised = self._document(
+            spdx_id="MIT", name="MIT", confidence=0.98,
+            confidence_level=LicenseConfidenceLevel.HIGH,
+            category="detected", match_type="text_similarity",
+        )["licensing"]["declared_licenses"][0]
+
+        assert declared["spdx_id"] == recognised["spdx_id"]
+        assert declared["category"] != recognised["category"]
+        assert declared["confidence_level"] != recognised["confidence_level"]
+
+
+class TestEveryDeclaredNameGoesThroughOneGate:
+    """Nine extractors had the same block copied into them. Converting five
+    left npm, Ruby, Rust, Gradle, Maven and NuGet still reporting an inferred
+    identifier as an exact tag match."""
+
+    def test_no_extractor_synthesises_a_licence_document_any_more(self):
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2] / "src" / "upmex"
+        offenders = []
+        for path in root.rglob("*.py"):
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                if 'formatted_text = f"License: ' in line:
+                    offenders.append(f"{path.name}:{number}")
+
+        # The ones that remain read the contents of a real licence file, where
+        # a short file holding just an identifier is the file declaring it.
+        for offender in offenders:
+            assert offender.startswith(("go_extractor", "rust_extractor")), offender

--- a/tests/unit/test_nuget_licenses.py
+++ b/tests/unit/test_nuget_licenses.py
@@ -60,7 +60,8 @@ class TestLicenseExpression:
     def test_recognised_identifier(self, tmp_path):
         path = make_nupkg(tmp_path / "p.nupkg", '<license type="expression">MIT</license>')
 
-        assert licenses_of(path) == [("MIT", "osslili_tag")]
+        # A name the package declared, resolved to the identifier it names.
+        assert licenses_of(path) == [("MIT", "declared_name")]
 
     @pytest.mark.parametrize('expression', [
         'MIT OR Apache-2.0',


### PR DESCRIPTION
Closes #108.

Three claims upmex made that it had not earned. All verified against live packages.

## Exact meant "the number was high"

`confidence >= 0.95` was reported as `exact`. So packaging's `BSD-2-Clause` — a **0.988 similarity** against `LICENSE.BSD` — came back exact, which tells a consumer the file *named* that licence rather than resembling it.

Exact now means the detector read a declaration: a tag or an SPDX identifier. A similarity score is `high` however close it gets, and the number is still there for anyone who wants it.

## Nothing said where a licence came from

Every licence came back with `file_path: None`. osslili reports which file it read, whether the licence is `declared` or merely `detected`, and how it matched — and all three were dropped. The file was overwritten with the path we handed in, which for a file scan is a **temporary copy** and for a directory scan was the only real provenance there was.

All three are carried now, through the extractor and into the JSON output.

## And the one the issue did not name

Nine extractors resolved a declared licence *name* by writing `"License: {name}"` to a file and asking the text detector what it said — then reporting the answer as a **tag match at confidence 1.0 from a filename they invented**.

packaging's classifier says `License :: OSI Approved :: BSD License`. BSD names four licences. That produced `BSD-3-Clause`, exact, for a project that uses the two-clause one.

One helper does this now. It keeps the identifier — resolving the name is worth doing — and says the name was *declared* rather than the text read. It is exact only where the declared name **is** the identifier.

## What it looks like now

```
packaging   BSD-3-Clause   high   declared  declared_name     METADATA
            Apache-2.0     high   detected  text_similarity   LICENSE.APACHE
            BSD-2-Clause   high   detected  text_similarity   LICENSE.BSD

click       BSD-3-Clause   exact  declared  declared_name     METADATA
            BSD-4-Clause   high   detected  text_similarity   LICENSE.rst

urllib3     MIT            high   declared  declared_name     METADATA
            JSON           high   detected  text_similarity   LICENSE.txt
```

click's `BSD-3-Clause` stays exact because its METADATA declares that identifier literally. Its `BSD-4-Clause` — the near-miss this issue is about — is now visibly a similarity match against a licence file, and rankable below the declaration.

That JSON phantom in urllib3 is the one that reached purl2notices and put the "Good, not Evil" licence into a customer's notices file. It is still reported, because osslili did detect it, and it now carries enough for a consumer to rank it where it belongs.

## A compound expression is kept whole

`MIT OR Apache-2.0` is a choice the package offers. Reporting one arm says something the package did not: a consumer who may not use Apache-2.0 needs to see that MIT is on offer. The separator is matched as a word, not a substring, so `Standard ML of New Jersey` is not read as a conjunction.

## What review added

- **The output still dropped it.** `category` and `match_type` reached `LicenseInfo` and stopped there, so the JSON a consumer reads was unchanged.
- **I had converted 5 of 13 sites.** npm, Ruby, Rust, Gradle, Maven, NuGet and the ecosyste.ms and PurlDB enrichment paths all still reported an inferred identifier as an exact tag match. All converted; a test fails if a new one appears.
- **The old directory-scan fallback** still used the numeric-only mapper.
- Two converted sites had lost the real file they came from.

**Not converted, deliberately:** the Go and Rust paths that read the contents of a real licence file. A short file holding just an identifier is that file declaring it, and the path they report is real.

263 tests, up from 222. 8 mutations each fail at least one test, after three rounds that found gaps in my own tests — including one where the mutation and the fix agreed because the case I chose was never resolvable in the first place.