### PR TITLE
Read the api config, and leave stdout to the output document

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -2,13 +2,25 @@
   "api": {
     "clearlydefined": {
       "enabled": true,
-      "base_url": "https://api.clearlydefined.io/v1",
+      "base_url": "https://api.clearlydefined.io",
       "timeout": 30,
       "api_key": null
     },
     "ecosystems": {
       "enabled": true,
-      "base_url": "https://api.ecosyste.ms/v1",
+      "base_url": "https://packages.ecosyste.ms/api/v1",
+      "timeout": 30,
+      "api_key": null
+    },
+    "purldb": {
+      "enabled": true,
+      "base_url": "https://public.purldb.io",
+      "timeout": 30,
+      "api_key": null
+    },
+    "vulnerablecode": {
+      "enabled": true,
+      "base_url": "https://public.vulnerablecode.io",
       "timeout": 30,
       "api_key": null
     }
@@ -21,7 +33,10 @@
     "cache_dir": null
   },
   "license_detection": {
-    "methods": ["regex", "dice_sorensen"],
+    "methods": [
+      "regex",
+      "dice_sorensen"
+    ],
     "confidence_threshold": 0.85,
     "max_text_length": 100000,
     "enable_ml": false

--- a/src/upmex/api/clearlydefined.py
+++ b/src/upmex/api/clearlydefined.py
@@ -1,24 +1,55 @@
 """ClearlyDefined API integration for license and metadata enrichment."""
 
+import logging
 import requests
 from typing import Optional, Dict, Any
+from ..config import setting
 from ..core.models import MAVEN_PACKAGE_TYPES, PackageType, NO_ASSERTION
+
+logger = logging.getLogger(__name__)
 
 
 class ClearlyDefinedAPI:
     """Client for ClearlyDefined API."""
     
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        config: Optional[Any] = None,
+    ):
         """Initialize ClearlyDefined API client.
-        
+
+        The configuration declares enabled, base_url, timeout and api_key for
+        this client, and none of them was read: the base URL was hardcoded,
+        the timeout was requests' own default, and setting enabled to false
+        disabled nothing. Worse, the configured base URL carried a /v1 prefix
+        that ClearlyDefined answers 404 for, so wiring it up as written would
+        have broken the integration rather than fixed it. That prefix is gone
+        and the settings are read.
+
         Args:
-            api_key: Optional API key for authenticated requests
+            api_key: API key for authenticated requests. Overrides the
+                configured one, so a caller that has a key can pass it.
+            config: Configuration to read the rest from. The defaults are
+                used when none is given.
         """
-        self.base_url = "https://api.clearlydefined.io"
-        self.api_key = api_key
+        if config is None:
+            from ..config import Config
+
+            config = Config()
+
+        self.enabled = setting(config, 'api.clearlydefined.enabled', True)
+        self.base_url = (
+            setting(config, 'api.clearlydefined.base_url', None)
+            or "https://api.clearlydefined.io"
+        ).rstrip('/')
+        self.timeout = setting(config, 'api.clearlydefined.timeout', 30)
+        self.api_key = api_key or setting(
+            config, 'api.clearlydefined.api_key', None
+        )
         self.headers = {}
-        if api_key:
-            self.headers['Authorization'] = f'Bearer {api_key}'
+        if self.api_key:
+            self.headers['Authorization'] = f'Bearer {self.api_key}'
     
     def get_definition(self, package_type: PackageType, namespace: Optional[str], name: str, version: str) -> Optional[Dict[str, Any]]:
         """Get package definition from ClearlyDefined.
@@ -30,8 +61,18 @@ class ClearlyDefinedAPI:
             version: Package version
             
         Returns:
-            Package definition or None
+            Package definition or None, and None when the client is switched
+            off in configuration.
         """
+        if not self.enabled:
+            # Setting this to false disabled nothing, so a deployment that
+            # asked not to reach ClearlyDefined reached it anyway.
+            logger.debug(
+                "ClearlyDefined is disabled in configuration; not querying %s",
+                name,
+            )
+            return None
+
         try:
             # Map package type to ClearlyDefined type and provider
             cd_info = self._map_package_type(package_type)
@@ -55,13 +96,13 @@ class ClearlyDefinedAPI:
             
             # Make API request
             url = f"{self.base_url}/definitions/{coordinates}"
-            response = requests.get(url, headers=self.headers, timeout=10)
+            response = requests.get(url, headers=self.headers, timeout=self.timeout)
             
             if response.status_code == 200:
                 return response.json()
             
         except Exception as e:
-            print(f"Error fetching from ClearlyDefined: {e}")
+            logger.warning(f"Error fetching from ClearlyDefined: {e}")
         
         return None
     
@@ -119,6 +160,6 @@ class ClearlyDefinedAPI:
                         'confidence': 0.8
                     }
         except Exception as e:
-            print(f"Error extracting license from ClearlyDefined: {e}")
+            logger.warning(f"Error extracting license from ClearlyDefined: {e}")
         
         return None

--- a/src/upmex/api/ecosystems.py
+++ b/src/upmex/api/ecosystems.py
@@ -1,24 +1,50 @@
 """Ecosyste.ms API integration for package metadata enrichment."""
 
+import logging
 import requests
 from typing import Optional, Dict, Any
+from ..config import setting
 from ..core.models import PackageType, NO_ASSERTION
+
+logger = logging.getLogger(__name__)
 
 
 class EcosystemsAPI:
     """Client for Ecosyste.ms API."""
     
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        config: Optional[Any] = None,
+    ):
         """Initialize Ecosyste.ms API client.
-        
+
+        The same defect the ClearlyDefined client had: the configuration
+        declares enabled, base_url, timeout and api_key for this client and
+        none of them was read, and the base_url it held does not resolve at
+        all, so wiring it up as written would have broken the integration.
+
         Args:
-            api_key: Optional API key for authenticated requests
+            api_key: API key for authenticated requests. Overrides the
+                configured one.
+            config: Configuration to read the rest from. The defaults are
+                used when none is given.
         """
-        self.base_url = "https://packages.ecosyste.ms/api/v1"
-        self.api_key = api_key
+        if config is None:
+            from ..config import Config
+
+            config = Config()
+
+        self.enabled = setting(config, 'api.ecosystems.enabled', True)
+        self.base_url = (
+            setting(config, 'api.ecosystems.base_url', None)
+            or "https://packages.ecosyste.ms/api/v1"
+        ).rstrip('/')
+        self.timeout = setting(config, 'api.ecosystems.timeout', 30)
+        self.api_key = api_key or setting(config, 'api.ecosystems.api_key', None)
         self.headers = {}
-        if api_key:
-            self.headers['Authorization'] = f'Bearer {api_key}'
+        if self.api_key:
+            self.headers['Authorization'] = f'Bearer {self.api_key}'
     
     def get_package_info(self, package_type: PackageType, name: str, version: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """Get package information from Ecosyste.ms.
@@ -31,6 +57,12 @@ class EcosystemsAPI:
         Returns:
             Package information or None
         """
+        if not self.enabled:
+            logger.debug(
+                "Ecosyste.ms is disabled in configuration; not querying %s", name
+            )
+            return None
+
         try:
             # Map package type to Ecosyste.ms registry
             registry = self._map_package_type(package_type)
@@ -39,7 +71,7 @@ class EcosystemsAPI:
             
             # Get package-level info first for maintainers
             package_url = f"{self.base_url}/registries/{registry}/packages/{name}"
-            package_response = requests.get(package_url, headers=self.headers, timeout=10)
+            package_response = requests.get(package_url, headers=self.headers, timeout=self.timeout)
             
             if package_response.status_code == 200:
                 package_data = package_response.json()
@@ -47,7 +79,7 @@ class EcosystemsAPI:
                 # If version requested, get version-specific data and merge
                 if version:
                     version_url = f"{package_url}/versions/{version}"
-                    version_response = requests.get(version_url, headers=self.headers, timeout=10)
+                    version_response = requests.get(version_url, headers=self.headers, timeout=self.timeout)
                     if version_response.status_code == 200:
                         version_data = version_response.json()
                         # Merge package data into version data, preserving key package-level metadata
@@ -61,7 +93,7 @@ class EcosystemsAPI:
                 return package_data
             
         except Exception as e:
-            print(f"Error fetching from Ecosyste.ms: {e}")
+            logger.warning(f"Error fetching from Ecosyste.ms: {e}")
         
         return None
     
@@ -129,6 +161,6 @@ class EcosystemsAPI:
                 metadata['maintainers'] = package_info['maintainers']
             
         except Exception as e:
-            print(f"Error extracting metadata from Ecosyste.ms: {e}")
+            logger.warning(f"Error extracting metadata from Ecosyste.ms: {e}")
         
         return metadata

--- a/src/upmex/api/maven_central.py
+++ b/src/upmex/api/maven_central.py
@@ -1,10 +1,13 @@
 """Maven Central registry integration for coordinate and POM lookups."""
 
+import logging
 import xml.etree.ElementTree as ET
 from functools import lru_cache
 from typing import Any, Dict, Optional, Tuple
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SEARCH_URL = "https://search.maven.org/solrsearch/select"
 DEFAULT_BASE_URL = "https://repo1.maven.org/maven2"
@@ -184,7 +187,7 @@ class MavenCentralAPI:
         try:
             result = _search_by_sha1(sha1.strip().lower(), self.search_url, self.timeout)
         except LookupFailed as e:
-            print(f"Error searching Maven Central by hash: {e}")
+            logger.warning(f"Error searching Maven Central by hash: {e}")
             return None
 
         if not result:
@@ -218,7 +221,7 @@ class MavenCentralAPI:
         try:
             pom_bytes = _fetch_pom_bytes(group_id, artifact_id, version, self.base_url, self.timeout)
         except LookupFailed as e:
-            print(f"Error fetching POM from Maven Central: {e}")
+            logger.warning(f"Error fetching POM from Maven Central: {e}")
             return None
 
         if not pom_bytes:
@@ -227,7 +230,7 @@ class MavenCentralAPI:
         try:
             root = ET.fromstring(pom_bytes)
         except Exception as e:
-            print(f"Error parsing POM from Maven Central: {e}")
+            logger.warning(f"Error parsing POM from Maven Central: {e}")
             return None
 
         # Only the header comments are read as text, and those are ASCII patterns

--- a/src/upmex/api/purldb.py
+++ b/src/upmex/api/purldb.py
@@ -1,25 +1,43 @@
 """PurlDB API integration for package metadata enrichment."""
 
+import logging
 import requests
 from typing import Optional, Dict, Any, List
+from ..config import setting
 from ..core.models import MAVEN_PACKAGE_TYPES, PackageType, NO_ASSERTION, split_namespace
+
+logger = logging.getLogger(__name__)
 
 
 class PurlDBAPI:
     """Client for PurlDB API."""
 
-    def __init__(self, api_key: Optional[str] = None, base_url: str = "https://public.purldb.io"):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        config: Optional[Any] = None,
+    ):
         """Initialize PurlDB API client.
 
         Args:
             api_key: Optional API key for authenticated requests
             base_url: Base URL for PurlDB instance
         """
-        self.base_url = base_url
-        self.api_key = api_key
+        if config is None:
+            from ..config import Config
+
+            config = Config()
+
+        self.enabled = setting(config, 'api.purldb.enabled', True)
+        self.base_url = (
+            base_url or setting(config, 'api.purldb.base_url', None) or "https://public.purldb.io"
+        ).rstrip('/')
+        self.timeout = setting(config, 'api.purldb.timeout', 30)
+        self.api_key = api_key or setting(config, 'api.purldb.api_key', None)
         self.headers = {'Content-Type': 'application/json'}
-        if api_key:
-            self.headers['Authorization'] = f'Token {api_key}'
+        if self.api_key:
+            self.headers['Authorization'] = f'Token {self.api_key}'
 
     def get_package_by_purl(self, purl: str) -> Optional[Dict[str, Any]]:
         """Get package information by PURL.
@@ -30,12 +48,18 @@ class PurlDBAPI:
         Returns:
             Package information or None
         """
+        if not self.enabled:
+            logger.debug(
+                "PurlDB is disabled in configuration; not querying %s", purl
+            )
+            return None
+
         try:
             # Use the packages endpoint with PURL query
             url = f"{self.base_url}/api/packages/"
             params = {'purl': purl}
 
-            response = requests.get(url, params=params, headers=self.headers, timeout=10)
+            response = requests.get(url, params=params, headers=self.headers, timeout=self.timeout)
 
             if response.status_code == 200:
                 data = response.json()
@@ -44,7 +68,7 @@ class PurlDBAPI:
                     return data['results'][0]
 
         except Exception as e:
-            print(f"Error fetching from PurlDB: {e}")
+            logger.warning(f"Error fetching from PurlDB: {e}")
 
         return None
 
@@ -59,6 +83,12 @@ class PurlDBAPI:
         Returns:
             Package information or None
         """
+        if not self.enabled:
+            logger.debug(
+                "PurlDB is disabled in configuration; not querying %s", name
+            )
+            return None
+
         try:
             # Map package type to PURL type
             purl_type = self._map_package_type(package_type)
@@ -86,7 +116,7 @@ class PurlDBAPI:
             if version:
                 params['version'] = version
 
-            response = requests.get(url, params=params, headers=self.headers, timeout=10)
+            response = requests.get(url, params=params, headers=self.headers, timeout=self.timeout)
 
             if response.status_code == 200:
                 data = response.json()
@@ -95,7 +125,7 @@ class PurlDBAPI:
                     return data['results'][0]
 
         except Exception as e:
-            print(f"Error fetching from PurlDB: {e}")
+            logger.warning(f"Error fetching from PurlDB: {e}")
 
         return None
 
@@ -203,6 +233,6 @@ class PurlDBAPI:
                 metadata['dependencies'] = package_info['dependencies']
 
         except Exception as e:
-            print(f"Error extracting metadata from PurlDB: {e}")
+            logger.warning(f"Error extracting metadata from PurlDB: {e}")
 
         return metadata

--- a/src/upmex/api/vulnerablecode.py
+++ b/src/upmex/api/vulnerablecode.py
@@ -1,25 +1,43 @@
 """VulnerableCode API integration for vulnerability information."""
 
+import logging
 import requests
 from typing import Optional, Dict, Any, List
+from ..config import setting
 from ..core.models import MAVEN_PACKAGE_TYPES, PackageType, split_namespace
+
+logger = logging.getLogger(__name__)
 
 
 class VulnerableCodeAPI:
     """Client for VulnerableCode API."""
 
-    def __init__(self, api_key: Optional[str] = None, base_url: str = "https://public.vulnerablecode.io"):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        config: Optional[Any] = None,
+    ):
         """Initialize VulnerableCode API client.
 
         Args:
             api_key: API key for authenticated requests (required for VulnerableCode)
             base_url: Base URL for VulnerableCode instance
         """
-        self.base_url = base_url
-        self.api_key = api_key
+        if config is None:
+            from ..config import Config
+
+            config = Config()
+
+        self.enabled = setting(config, 'api.vulnerablecode.enabled', True)
+        self.base_url = (
+            base_url or setting(config, 'api.vulnerablecode.base_url', None) or "https://public.vulnerablecode.io"
+        ).rstrip('/')
+        self.timeout = setting(config, 'api.vulnerablecode.timeout', 30)
+        self.api_key = api_key or setting(config, 'api.vulnerablecode.api_key', None)
         self.headers = {'Content-Type': 'application/json'}
-        if api_key:
-            self.headers['Authorization'] = f'Token {api_key}'
+        if self.api_key:
+            self.headers['Authorization'] = f'Token {self.api_key}'
 
     def get_vulnerabilities_by_purl(self, purl: str) -> Optional[Dict[str, Any]]:
         """Get vulnerability information by PURL.
@@ -30,28 +48,34 @@ class VulnerableCodeAPI:
         Returns:
             Vulnerability information or None
         """
+        if not self.enabled:
+            logger.debug(
+                "VulnerableCode is disabled in configuration; not querying %s", purl
+            )
+            return None
+
         if not self.api_key:
-            print("Warning: VulnerableCode API key not provided - skipping vulnerability check")
+            logger.warning("Warning: VulnerableCode API key not provided - skipping vulnerability check")
             return None
 
         try:
             url = f"{self.base_url}/api/packages"
             params = {'purl': purl}
 
-            response = requests.get(url, params=params, headers=self.headers, timeout=10)
+            response = requests.get(url, params=params, headers=self.headers, timeout=self.timeout)
 
             if response.status_code == 200:
                 data = response.json()
                 return data
             elif response.status_code == 401:
-                print("Warning: VulnerableCode API authentication failed - check API key")
+                logger.warning("Warning: VulnerableCode API authentication failed - check API key")
                 return None
             else:
-                print(f"Warning: VulnerableCode API returned status {response.status_code}")
+                logger.warning(f"Warning: VulnerableCode API returned status {response.status_code}")
                 return None
 
         except Exception as e:
-            print(f"Error fetching from VulnerableCode: {e}")
+            logger.warning(f"Error fetching from VulnerableCode: {e}")
 
         return None
 
@@ -93,7 +117,7 @@ class VulnerableCodeAPI:
             return self.get_vulnerabilities_by_purl(purl)
 
         except Exception as e:
-            print(f"Error constructing PURL for VulnerableCode: {e}")
+            logger.warning(f"Error constructing PURL for VulnerableCode: {e}")
 
         return None
 
@@ -213,6 +237,6 @@ class VulnerableCodeAPI:
                     vulnerabilities['fixing_packages'].append(package_info)
 
         except Exception as e:
-            print(f"Error extracting vulnerabilities from VulnerableCode: {e}")
+            logger.warning(f"Error extracting vulnerabilities from VulnerableCode: {e}")
 
         return vulnerabilities

--- a/src/upmex/cli.py
+++ b/src/upmex/cli.py
@@ -95,9 +95,9 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
         
         # Extract metadata
         if verbose:
-            click.echo(f"Extracting metadata from: {package_path}")
+            click.echo(f"Extracting metadata from: {package_path}", err=True)
             if registry:
-                click.echo("Registry mode enabled - will fetch missing metadata")
+                click.echo("Registry mode enabled - will fetch missing metadata", err=True)
         
         metadata = extractor.extract(package_path)
 
@@ -106,9 +106,9 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
             # API enrichment only when --api is specified (with or without --registry)
             if verbose:
                 if registry:
-                    click.echo("Using both registry and third-party API enrichment")
+                    click.echo("Using both registry and third-party API enrichment", err=True)
                 else:
-                    click.echo("Using third-party API enrichment only")
+                    click.echo("Using third-party API enrichment only", err=True)
             try:
                 from .api.clearlydefined import ClearlyDefinedAPI
                 from .api.ecosystems import EcosystemsAPI
@@ -118,63 +118,71 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
 
                 if api in ['clearlydefined', 'all']:
                     if verbose:
-                        click.echo("Enriching with ClearlyDefined API...")
+                        click.echo("Enriching with ClearlyDefined API...", err=True)
 
-                        cd_api = ClearlyDefinedAPI()
+                    # The enrichment below used to sit inside that if, so
+                    # --api clearlydefined fetched nothing at all unless the caller
+                    # also happened to ask for verbose output.
 
-                        # Parse namespace from name for Maven packages
-                        namespace, name = split_namespace(metadata.package_type, metadata.name)
+                    # The command already holds the configuration --config
+                    # produced. Letting the client build its own meant
+                    # api.clearlydefined settings, enabled included, were read
+                    # from the defaults whatever the caller asked for.
+                    cd_api = ClearlyDefinedAPI(config=config)
 
-                        cd_data = cd_api.get_definition(
-                            package_type=metadata.package_type,
-                            namespace=namespace,
-                            name=name,
-                            version=metadata.version
-                        )
+                    # Parse namespace from name for Maven packages
+                    namespace, name = split_namespace(metadata.package_type, metadata.name)
 
-                        if cd_data:
-                            applied_fields = []
+                    cd_data = cd_api.get_definition(
+                        package_type=metadata.package_type,
+                        namespace=namespace,
+                        name=name,
+                        version=metadata.version
+                    )
 
-                            # Enrich licensing information
-                            cd_license = cd_api.extract_license_info(cd_data)
-                            if cd_license:
-                                from upmex.core.models import LicenseInfo, LicenseConfidenceLevel
-                                license_obj = LicenseInfo(
-                                    spdx_id=cd_license['spdx_id'],
-                                    confidence=cd_license['confidence'],
-                                    confidence_level=LicenseConfidenceLevel.EXACT if cd_license['confidence'] >= 0.95 else LicenseConfidenceLevel.HIGH,
-                                    detection_method='ClearlyDefined API',
-                                    file_path='clearlydefined_api'
-                                )
-                                metadata.licenses.append(license_obj)
-                                metadata.provenance['licenses_clearlydefined'] = f"clearlydefined:{cd_api.base_url}"
-                                applied_fields.append('licenses')
+                    if cd_data:
+                        applied_fields = []
 
-                            # Enrich other metadata if available
-                            if cd_data.get('described', {}).get('projectWebsite') and (not metadata.homepage or metadata.homepage == NO_ASSERTION):
-                                metadata.homepage = cd_data['described']['projectWebsite']
-                                metadata.provenance['homepage'] = f"clearlydefined:{cd_api.base_url}"
-                                applied_fields.append('homepage')
+                        # Enrich licensing information
+                        cd_license = cd_api.extract_license_info(cd_data)
+                        if cd_license:
+                            from upmex.core.models import LicenseInfo, LicenseConfidenceLevel
+                            license_obj = LicenseInfo(
+                                spdx_id=cd_license['spdx_id'],
+                                confidence=cd_license['confidence'],
+                                confidence_level=LicenseConfidenceLevel.EXACT if cd_license['confidence'] >= 0.95 else LicenseConfidenceLevel.HIGH,
+                                detection_method='ClearlyDefined API',
+                                file_path='clearlydefined_api'
+                            )
+                            metadata.licenses.append(license_obj)
+                            metadata.provenance['licenses_clearlydefined'] = f"clearlydefined:{cd_api.base_url}"
+                            applied_fields.append('licenses')
 
-                            # Track API enrichment
-                            if applied_fields:
-                                metadata.add_enrichment(
-                                    source="clearlydefined",
-                                    source_type="api",
-                                    data=cd_data,
-                                    applied_fields=applied_fields
-                                )
+                        # Enrich other metadata if available
+                        if cd_data.get('described', {}).get('projectWebsite') and (not metadata.homepage or metadata.homepage == NO_ASSERTION):
+                            metadata.homepage = cd_data['described']['projectWebsite']
+                            metadata.provenance['homepage'] = f"clearlydefined:{cd_api.base_url}"
+                            applied_fields.append('homepage')
 
-                            if verbose:
-                                click.echo(f"✓ ClearlyDefined enrichment completed")
-                        elif verbose:
-                            click.echo("○ No ClearlyDefined data available")
+                        # Track API enrichment
+                        if applied_fields:
+                            metadata.add_enrichment(
+                                source="clearlydefined",
+                                source_type="api",
+                                data=cd_data,
+                                applied_fields=applied_fields
+                            )
+
+                        if verbose:
+                            click.echo(f"✓ ClearlyDefined enrichment completed", err=True)
+                    elif verbose:
+                        click.echo("○ No ClearlyDefined data available", err=True)
 
                 if api in ['ecosystems', 'all']:
                     if verbose:
-                        click.echo("Enriching with Ecosystems API...")
+                        click.echo("Enriching with Ecosystems API...", err=True)
 
-                    eco_api = EcosystemsAPI()
+                    eco_api = EcosystemsAPI(config=config)
                     eco_info = eco_api.get_package_info(metadata.package_type, metadata.name, metadata.version)
 
                     if eco_info:
@@ -261,15 +269,15 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
                             )
 
                         if verbose:
-                            click.echo(f"✓ Ecosystems enrichment completed")
+                            click.echo(f"✓ Ecosystems enrichment completed", err=True)
                     elif verbose:
-                        click.echo("○ No Ecosystems data available")
+                        click.echo("○ No Ecosystems data available", err=True)
 
                 if api in ['purldb', 'all']:
                     if verbose:
-                        click.echo("Enriching with PurlDB API...")
+                        click.echo("Enriching with PurlDB API...", err=True)
 
-                    purldb_api = PurlDBAPI()
+                    purldb_api = PurlDBAPI(config=config)
                     purldb_info = purldb_api.get_package_info(metadata.package_type, metadata.name, metadata.version)
 
                     if purldb_info:
@@ -332,17 +340,22 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
                             )
 
                         if verbose:
-                            click.echo(f"✓ PurlDB enrichment completed")
+                            click.echo(f"✓ PurlDB enrichment completed", err=True)
                     elif verbose:
-                        click.echo("○ No PurlDB data available")
+                        click.echo("○ No PurlDB data available", err=True)
 
                 if api in ['vulnerablecode', 'all']:
                     if verbose:
-                        click.echo("Enriching with VulnerableCode API...")
+                        click.echo("Enriching with VulnerableCode API...", err=True)
 
-                    # Get API key from config or environment
+                    # A config file written before api.vulnerablecode.api_key
+                    # existed carries the key at the top level. Keep honouring
+                    # it, and let it win over the nested value the way an
+                    # explicit argument always has.
                     vulnerablecode_api_key = config.get('vulnerablecode_api_key') or None
-                    vulnerablecode_api = VulnerableCodeAPI(api_key=vulnerablecode_api_key)
+                    vulnerablecode_api = VulnerableCodeAPI(
+                        api_key=vulnerablecode_api_key, config=config
+                    )
                     vuln_data = vulnerablecode_api.get_vulnerabilities(metadata.package_type, metadata.name, metadata.version)
 
                     if vuln_data:
@@ -362,12 +375,12 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
                             if verbose:
                                 total = vulnerabilities['total_count']
                                 vulnerable = len(vulnerabilities['vulnerable_packages'])
-                                click.echo(f"✓ VulnerableCode found {total} entries, {vulnerable} vulnerable")
+                                click.echo(f"✓ VulnerableCode found {total} entries, {vulnerable} vulnerable", err=True)
                         else:
                             if verbose:
-                                click.echo("✓ VulnerableCode found no vulnerabilities")
+                                click.echo("✓ VulnerableCode found no vulnerabilities", err=True)
                     elif verbose:
-                        click.echo("○ No VulnerableCode data available")
+                        click.echo("○ No VulnerableCode data available", err=True)
 
             except ImportError as e:
                 click.echo(f"Warning: API enrichment dependencies not available: {e}", err=True)
@@ -382,7 +395,7 @@ def extract(ctx, package_path, output, format, pretty, api, registry):
         if output:
             Path(output).write_text(output_text)
             if not ctx.obj['quiet']:
-                click.echo(f"Output written to: {output}")
+                click.echo(f"Output written to: {output}", err=True)
         else:
             click.echo(output_text)
             
@@ -406,12 +419,13 @@ def detect(ctx, package_path, verbose):
         package_type = detect_package_type(package_path)
         
         if verbose:
+            # The type is what a caller reads off this command, so it stays on
+            # stdout at either verbosity and the commentary goes beside it.
             path = Path(package_path)
-            click.echo(f"File: {path.name}")
-            click.echo(f"Size: {path.stat().st_size:,} bytes")
-            click.echo(f"Type: {package_type.value}")
-        else:
-            click.echo(package_type.value)
+            click.echo(f"File: {path.name}", err=True)
+            click.echo(f"Size: {path.stat().st_size:,} bytes", err=True)
+
+        click.echo(package_type.value)
             
     except Exception as e:
         click.echo(f"Error: {e}", err=True)

--- a/src/upmex/config.py
+++ b/src/upmex/config.py
@@ -4,6 +4,27 @@ import os
 import json
 from pathlib import Path
 from typing import Dict, Any, Optional
+import copy
+
+
+def setting(config: Any, key: str, default: Any = None) -> Any:
+    """Read a dotted setting from a Config or from a plain nested mapping.
+
+    The CLI holds a Config, whose get understands the dotted key. The
+    extractors are handed what Config.to_dict() produced, which is an ordinary
+    nested dict and answers that key with the default. Reading both means a
+    setting reaches whichever of them asks.
+    """
+    value = config.get(key, default) if hasattr(config, 'get') else default
+    if value is not default:
+        return value
+
+    node = config
+    for part in key.split('.'):
+        if not isinstance(node, dict) or part not in node:
+            return default
+        node = node[part]
+    return node
 
 
 class Config:
@@ -13,13 +34,25 @@ class Config:
         "api": {
             "clearlydefined": {
                 "enabled": True,
-                "base_url": "https://api.clearlydefined.io/v1",
+                "base_url": "https://api.clearlydefined.io",
                 "timeout": 30,
                 "api_key": None  # Set via PME_CLEARLYDEFINED_API_KEY env var
             },
+            "purldb": {
+                "enabled": True,
+                "base_url": "https://public.purldb.io",
+                "timeout": 30,
+                "api_key": None  # Set via PME_PURLDB_API_KEY env var
+            },
+            "vulnerablecode": {
+                "enabled": True,
+                "base_url": "https://public.vulnerablecode.io",
+                "timeout": 30,
+                "api_key": None  # Set via PME_VULNERABLECODE_API_KEY env var
+            },
             "ecosystems": {
                 "enabled": True,
-                "base_url": "https://api.ecosyste.ms/v1",
+                "base_url": "https://packages.ecosyste.ms/api/v1",
                 "timeout": 30,
                 "api_key": None  # Set via PME_ECOSYSTEMS_API_KEY env var
             }
@@ -53,6 +86,10 @@ class Config:
     ENV_VAR_MAPPING = {
         "PME_CLEARLYDEFINED_API_KEY": "api.clearlydefined.api_key",
         "PME_ECOSYSTEMS_API_KEY": "api.ecosystems.api_key",
+        # Documented in the README and mapped to nothing, so exporting either
+        # of these set a key that never reached the client.
+        "PME_PURLDB_API_KEY": "api.purldb.api_key",
+        "PME_VULNERABLECODE_API_KEY": "api.vulnerablecode.api_key",
         "PME_API_TIMEOUT": "api.*.timeout",
         "PME_MAX_FILE_SIZE": "extraction.max_file_size",
         "PME_TEMP_DIR": "extraction.temp_dir",
@@ -72,7 +109,11 @@ class Config:
         Args:
             config_file: Optional path to configuration file
         """
-        self.config = self.DEFAULT_CONFIG.copy()
+        # Deep, because set() writes into the nested dicts: a shallow copy
+        # shares them with DEFAULT_CONFIG, so one instance calling set()
+        # changed what every later Config() and every default-constructed
+        # client would read, for the life of the process.
+        self.config = copy.deepcopy(self.DEFAULT_CONFIG)
         
         # Load from file if provided
         if config_file:

--- a/src/upmex/core/extractor.py
+++ b/src/upmex/core/extractor.py
@@ -1,5 +1,6 @@
 """Main package extractor orchestrator."""
 
+import logging
 import os
 import hashlib
 from pathlib import Path
@@ -29,6 +30,8 @@ from ..utils.package_detector import detect_package_type
 from ..api.clearlydefined import ClearlyDefinedAPI
 from ..api.ecosystems import EcosystemsAPI
 
+logger = logging.getLogger(__name__)
+
 
 class PackageExtractor:
     """Main class for extracting package metadata."""
@@ -44,22 +47,22 @@ class PackageExtractor:
         
         # Initialize extractors with registry mode
         self.extractors = {
-            PackageType.PYTHON_WHEEL: PythonExtractor(registry_mode=self.registry_mode),
-            PackageType.PYTHON_SDIST: PythonExtractor(registry_mode=self.registry_mode),
-            PackageType.NPM: NpmExtractor(registry_mode=self.registry_mode),
-            PackageType.MAVEN: JavaExtractor(registry_mode=self.registry_mode),
-            PackageType.JAR: JavaExtractor(registry_mode=self.registry_mode),
-            PackageType.GRADLE: GradleExtractor(registry_mode=self.registry_mode),
-            PackageType.COCOAPODS: CocoaPodsExtractor(registry_mode=self.registry_mode),
-            PackageType.CONDA: CondaExtractor(registry_mode=self.registry_mode),
+            PackageType.PYTHON_WHEEL: PythonExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.PYTHON_SDIST: PythonExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.NPM: NpmExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.MAVEN: JavaExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.JAR: JavaExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.GRADLE: GradleExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.COCOAPODS: CocoaPodsExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.CONDA: CondaExtractor(registry_mode=self.registry_mode, config=self.config),
             PackageType.CONAN: ConanExtractor(),
             PackageType.PERL: PerlExtractor(),
-            PackageType.RUBY_GEM: RubyExtractor(registry_mode=self.registry_mode),
-            PackageType.RUST_CRATE: RustExtractor(registry_mode=self.registry_mode),
-            PackageType.GO_MODULE: GoExtractor(registry_mode=self.registry_mode),
-            PackageType.NUGET: NuGetExtractor(registry_mode=self.registry_mode),
-            PackageType.RPM: RpmExtractor(registry_mode=self.registry_mode),
-            PackageType.DEB: DebianExtractor(registry_mode=self.registry_mode),
+            PackageType.RUBY_GEM: RubyExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.RUST_CRATE: RustExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.GO_MODULE: GoExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.NUGET: NuGetExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.RPM: RpmExtractor(registry_mode=self.registry_mode, config=self.config),
+            PackageType.DEB: DebianExtractor(registry_mode=self.registry_mode, config=self.config),
         }
     
     def extract(self, package_path: str) -> PackageMetadata:
@@ -124,7 +127,10 @@ class PackageExtractor:
             namespace, name = split_namespace(metadata.package_type, metadata.name)
             
             # Try ClearlyDefined
-            cd_api = ClearlyDefinedAPI(api_key=self.config.get('clearlydefined_api_key'))
+            cd_api = ClearlyDefinedAPI(
+                api_key=self.config.get('clearlydefined_api_key'),
+                config=self.config,
+            )
             cd_def = cd_api.get_definition(metadata.package_type, namespace, name, metadata.version)
             if cd_def:
                 # Extract license info
@@ -138,7 +144,10 @@ class PackageExtractor:
                     ))
             
             # Try Ecosyste.ms
-            eco_api = EcosystemsAPI(api_key=self.config.get('ecosystems_api_key'))
+            eco_api = EcosystemsAPI(
+                api_key=self.config.get('ecosystems_api_key'),
+                config=self.config,
+            )
             eco_info = eco_api.get_package_info(metadata.package_type, metadata.name, metadata.version)
             if eco_info:
                 eco_metadata = eco_api.extract_metadata(eco_info)
@@ -209,7 +218,7 @@ class PackageExtractor:
                             metadata.licenses.extend(license_infos)
                 
         except Exception as e:
-            print(f"Error enriching with APIs: {e}")
+            logger.warning(f"Error enriching with APIs: {e}")
     
     def _calculate_hash(self, file_path: str, algorithm: str = "sha256") -> str:
         """Calculate file hash.

--- a/src/upmex/extractors/base.py
+++ b/src/upmex/extractors/base.py
@@ -29,13 +29,17 @@ class BaseExtractor(ABC):
     # Common license file patterns (using shared patterns)
     LICENSE_FILE_PATTERNS = LICENSE_FILE_NAMES
     
-    def __init__(self, registry_mode: bool = False):
+    def __init__(self, registry_mode: bool = False, config: Any = None):
         """Initialize extractor.
 
         Args:
             registry_mode: Whether to fetch additional data from package registries
         """
         self.registry_mode = registry_mode
+        # The configuration the caller was given, so an API client built in
+        # here honours --config rather than reading the defaults. None means
+        # nothing was threaded through and the defaults apply.
+        self.config = config
     
     @abstractmethod
     def extract(self, package_path: str) -> PackageMetadata:
@@ -413,7 +417,7 @@ class BaseExtractor(ABC):
         try:
             from ..api.clearlydefined import ClearlyDefinedAPI
 
-            cd_api = ClearlyDefinedAPI()
+            cd_api = ClearlyDefinedAPI(config=self.config)
 
             # Parse namespace based on package type
             namespace, name = split_namespace(metadata.package_type, metadata.name)

--- a/src/upmex/extractors/conan_extractor.py
+++ b/src/upmex/extractors/conan_extractor.py
@@ -15,9 +15,9 @@ from ..core.models import PackageMetadata, PackageType, LicenseInfo, NO_ASSERTIO
 class ConanExtractor(BaseExtractor):
     """Extractor for Conan C/C++ packages."""
     
-    def __init__(self, registry_mode: bool = False):
+    def __init__(self, registry_mode: bool = False, config: Any = None):
         """Initialize the Conan extractor."""
-        super().__init__(registry_mode)
+        super().__init__(registry_mode, config)
     
     def extract(self, package_path: str) -> PackageMetadata:
         """Extract metadata from a Conan package.

--- a/src/upmex/extractors/go_extractor.py
+++ b/src/upmex/extractors/go_extractor.py
@@ -137,7 +137,7 @@ class GoExtractor(BaseExtractor):
                 if copyright_statement:
                     metadata.copyright = copyright_statement
             except Exception as e:
-                print(f"Error extracting for copyright: {e}")
+                logger.warning(f"Error extracting for copyright: {e}")
 
         return metadata
 

--- a/src/upmex/extractors/gradle_extractor.py
+++ b/src/upmex/extractors/gradle_extractor.py
@@ -1,10 +1,13 @@
 """Gradle build file extractor."""
 
+import logging
 import re
 from pathlib import Path
 from typing import Dict, Any, Optional, List
 from .base import BaseExtractor
 from ..core.models import PackageMetadata, PackageType, NO_ASSERTION
+
+logger = logging.getLogger(__name__)
 
 
 class GradleExtractor(BaseExtractor):
@@ -64,7 +67,7 @@ class GradleExtractor(BaseExtractor):
             metadata.keywords = self._extract_keywords(content, is_kotlin_dsl)
             
         except Exception as e:
-            print(f"Error extracting Gradle metadata: {e}")
+            logger.warning(f"Error extracting Gradle metadata: {e}")
         
         return metadata
     

--- a/src/upmex/extractors/java_extractor.py
+++ b/src/upmex/extractors/java_extractor.py
@@ -1,5 +1,6 @@
 """Java/Maven package extractor."""
 
+import logging
 import zipfile
 import xml.etree.ElementTree as ET
 import re
@@ -16,13 +17,15 @@ from ..core.models import (
     split_namespace,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class JavaExtractor(BaseExtractor):
     """Extractor for Java JAR and Maven packages."""
     
-    def __init__(self, registry_mode: bool = False):
+    def __init__(self, registry_mode: bool = False, config: Any = None):
         """Initialize the Java extractor."""
-        super().__init__(registry_mode)
+        super().__init__(registry_mode, config)
         self.maven_central_url = "https://repo1.maven.org/maven2"
         self._maven_central = MavenCentralAPI(base_url=self.maven_central_url)
     
@@ -60,7 +63,7 @@ class JavaExtractor(BaseExtractor):
                         self._resolve_from_file_hash(package_path, metadata)
                     except Exception as e:
                         # Optional enrichment must not cost us the local metadata
-                        print(f"Error resolving coordinates from file hash: {e}")
+                        logger.warning(f"Error resolving coordinates from file hash: {e}")
 
                 # Extract copyright information
                 import tempfile
@@ -81,10 +84,10 @@ class JavaExtractor(BaseExtractor):
                         if copyright_statement:
                             metadata.copyright = copyright_statement
                     except Exception as e:
-                        print(f"Error extracting for copyright: {e}")
+                        logger.warning(f"Error extracting for copyright: {e}")
                             
         except Exception as e:
-            print(f"Error extracting Java metadata: {e}")
+            logger.warning(f"Error extracting Java metadata: {e}")
         
         return metadata
     
@@ -229,7 +232,7 @@ class JavaExtractor(BaseExtractor):
                     
                     return metadata
                 except Exception as e:
-                    print(f"Error parsing POM file: {e}")
+                    logger.warning(f"Error parsing POM file: {e}")
         
         return None
     
@@ -256,7 +259,7 @@ class JavaExtractor(BaseExtractor):
                 # Store raw manifest
                 metadata.raw_metadata = manifest
         except Exception as e:
-            print(f"Error parsing MANIFEST.MF: {e}")
+            logger.warning(f"Error parsing MANIFEST.MF: {e}")
         
         return metadata
     
@@ -366,7 +369,7 @@ class JavaExtractor(BaseExtractor):
         except Exception as e:
             # Enrichment is optional: a registry problem must never cost the
             # caller the metadata that was parsed out of the archive itself.
-            print(f"Error applying parent POM: {e}")
+            logger.warning(f"Error applying parent POM: {e}")
             return []
 
     def _fetch_and_apply_parent_pom(self, root: Any, ns: Dict[str, str], metadata: PackageMetadata) -> List[str]:
@@ -541,7 +544,7 @@ class JavaExtractor(BaseExtractor):
                         file_path=file_path
                     ))
             except Exception as lic_err:
-                print(f"Error detecting license '{license_name}': {lic_err}")
+                logger.warning(f"Error detecting license '{license_name}': {lic_err}")
 
         return licenses
 
@@ -697,7 +700,7 @@ class JavaExtractor(BaseExtractor):
                         pom_data['licenses'] = license_infos
 
         except Exception as e:
-            print(f"Error parsing POM metadata: {e}")
+            logger.warning(f"Error parsing POM metadata: {e}")
 
         return pom_data
     
@@ -734,7 +737,7 @@ class JavaExtractor(BaseExtractor):
             return header_data if header_data else None
             
         except Exception as e:
-            print(f"Error parsing POM header: {e}")
+            logger.warning(f"Error parsing POM header: {e}")
 
         return None
 
@@ -743,7 +746,7 @@ class JavaExtractor(BaseExtractor):
         try:
             from ..api.clearlydefined import ClearlyDefinedAPI
 
-            cd_api = ClearlyDefinedAPI()
+            cd_api = ClearlyDefinedAPI(config=self.config)
 
             # Parse namespace from name for Maven packages
             namespace, name = split_namespace(metadata.package_type, metadata.name)
@@ -789,5 +792,5 @@ class JavaExtractor(BaseExtractor):
             pass
         except Exception as e:
             # Silently fail - ClearlyDefined enrichment is optional
-            print(f"ClearlyDefined enrichment failed: {e}")
+            logger.warning(f"ClearlyDefined enrichment failed: {e}")
             pass

--- a/src/upmex/extractors/npm_extractor.py
+++ b/src/upmex/extractors/npm_extractor.py
@@ -1,5 +1,6 @@
 """NPM package extractor - REFACTORED."""
 
+import logging
 import json
 from pathlib import Path
 from typing import Dict, Any
@@ -11,6 +12,8 @@ from ..core.models import (
     LicenseConfidenceLevel,
     NO_ASSERTION,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class NpmExtractor(BaseExtractor):
@@ -76,13 +79,13 @@ class NpmExtractor(BaseExtractor):
                     if copyright_statement:
                         metadata.copyright = copyright_statement
                 except Exception as e:
-                    print(f"Error extracting for copyright: {e}")
+                    logger.warning(f"Error extracting for copyright: {e}")
 
             # ClearlyDefined enrichment in online mode
             self.enrich_with_clearlydefined(metadata)
 
         except Exception as e:
-            print(f"Error extracting NPM metadata: {e}")
+            logger.warning(f"Error extracting NPM metadata: {e}")
 
         return metadata
     
@@ -96,14 +99,14 @@ class NpmExtractor(BaseExtractor):
         try:
             # Handle empty content
             if not content or len(content.strip()) == 0:
-                print("Warning: Empty package.json content, skipping")
+                logger.warning("Warning: Empty package.json content, skipping")
                 return
 
             data = json.loads(content)
 
             # Skip if data is empty or not a dict
             if not data or not isinstance(data, dict):
-                print("Warning: Invalid package.json structure, skipping")
+                logger.warning("Warning: Invalid package.json structure, skipping")
                 return
 
             # Extract basic metadata
@@ -162,7 +165,7 @@ class NpmExtractor(BaseExtractor):
             metadata.raw_metadata = data
             
         except Exception as e:
-            print(f"Error processing package.json: {e}")
+            logger.warning(f"Error processing package.json: {e}")
     
     def _extract_license(self, metadata: PackageMetadata, data: Dict):
         """Extract license information from package.json."""

--- a/src/upmex/extractors/perl_extractor.py
+++ b/src/upmex/extractors/perl_extractor.py
@@ -15,9 +15,9 @@ from ..core.models import PackageMetadata, PackageType, LicenseInfo, NO_ASSERTIO
 class PerlExtractor(BaseExtractor):
     """Extractor for Perl/CPAN packages."""
     
-    def __init__(self, registry_mode: bool = False):
+    def __init__(self, registry_mode: bool = False, config: Any = None):
         """Initialize the Perl extractor."""
-        super().__init__(registry_mode)
+        super().__init__(registry_mode, config)
     
     def extract(self, package_path: str) -> PackageMetadata:
         """Extract metadata from a Perl package.

--- a/src/upmex/extractors/python_extractor.py
+++ b/src/upmex/extractors/python_extractor.py
@@ -1,11 +1,14 @@
 """Python package extractor for wheel and sdist formats - REFACTORED."""
 
+import logging
 import json
 import email
 from pathlib import Path
 from typing import Dict, Any, Optional
 from .base import BaseExtractor
 from ..core.models import PackageMetadata, PackageType, NO_ASSERTION
+
+logger = logging.getLogger(__name__)
 
 
 class PythonExtractor(BaseExtractor):
@@ -76,13 +79,13 @@ class PythonExtractor(BaseExtractor):
                     if copyright_statement:
                         metadata.copyright = copyright_statement
                 except Exception as e:
-                    print(f"Error extracting for copyright: {e}")
+                    logger.warning(f"Error extracting for copyright: {e}")
 
             # ClearlyDefined enrichment in online mode
             self.enrich_with_clearlydefined(metadata)
 
         except Exception as e:
-            print(f"Error extracting wheel metadata: {e}")
+            logger.warning(f"Error extracting wheel metadata: {e}")
 
         return metadata
     
@@ -125,13 +128,13 @@ class PythonExtractor(BaseExtractor):
                     if copyright_statement:
                         metadata.copyright = copyright_statement
                 except Exception as e:
-                    print(f"Error extracting for copyright: {e}")
+                    logger.warning(f"Error extracting for copyright: {e}")
 
             # ClearlyDefined enrichment in online mode
             self.enrich_with_clearlydefined(metadata)
 
         except Exception as e:
-            print(f"Error extracting sdist metadata: {e}")
+            logger.warning(f"Error extracting sdist metadata: {e}")
 
         return metadata
     
@@ -211,7 +214,7 @@ class PythonExtractor(BaseExtractor):
                     metadata.keywords = [k.strip() for k in keywords.split() if k.strip()]
                     
         except Exception as e:
-            print(f"Error processing metadata file: {e}")
+            logger.warning(f"Error processing metadata file: {e}")
     
     def _process_json_metadata(self, metadata: PackageMetadata, content: bytes):
         """Process metadata.json format."""
@@ -229,4 +232,4 @@ class PythonExtractor(BaseExtractor):
                     metadata.authors.append(parsed)
                     
         except Exception as e:
-            print(f"Error processing JSON metadata: {e}")
+            logger.warning(f"Error processing JSON metadata: {e}")

--- a/src/upmex/extractors/ruby_extractor.py
+++ b/src/upmex/extractors/ruby_extractor.py
@@ -255,7 +255,7 @@ class RubyExtractor(BaseExtractor):
                 if copyright_statement:
                     metadata.copyright = copyright_statement
             except Exception as e:
-                print(f"Error extracting for copyright: {e}")
+                logger.warning(f"Error extracting for copyright: {e}")
 
         # Query registry APIs if enabled
         if self.registry_mode and metadata.name != NO_ASSERTION:

--- a/src/upmex/extractors/rust_extractor.py
+++ b/src/upmex/extractors/rust_extractor.py
@@ -227,7 +227,7 @@ class RustExtractor(BaseExtractor):
                 if copyright_statement:
                     metadata.copyright = copyright_statement
             except Exception as e:
-                print(f"Error extracting for copyright: {e}")
+                logger.warning(f"Error extracting for copyright: {e}")
 
         # Query registry APIs if enabled
         if self.registry_mode and metadata.name != NO_ASSERTION:

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -2,13 +2,13 @@
 License detection using osslili CLI subprocess.
 """
 
+import logging
 import subprocess
 import json
 import tempfile
 import os
 from typing import List, Dict, Optional, Any
 from pathlib import Path
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +205,7 @@ class OssliliSubprocessDetector:
                 if 'scan_results' in data and data['scan_results']:
                     for sr in data['scan_results']:
                         if 'copyright_evidence' in sr and sr['copyright_evidence']:
-                            print(f"DEBUG: Found copyright evidence: {sr['copyright_evidence']}", file=sys.stderr)
+                            logger.debug(f"DEBUG: Found copyright evidence: {sr['copyright_evidence']}")
                 
                 # Extract licenses from evidence format
                 seen_licenses = set()
@@ -276,13 +276,13 @@ class OssliliSubprocessDetector:
                 # Extract copyrights from scan_results
                 seen_copyrights = set()
                 if 'scan_results' in data and data['scan_results']:
-                    print(f"DEBUG: Processing {len(data['scan_results'])} scan results for copyrights", file=sys.stderr)
+                    logger.debug(f"DEBUG: Processing {len(data['scan_results'])} scan results for copyrights")
                     for scan_result in data['scan_results']:
                         if 'copyright_evidence' in scan_result:
-                            print(f"DEBUG: Found {len(scan_result['copyright_evidence'])} copyright items", file=sys.stderr)
+                            logger.debug(f"DEBUG: Found {len(scan_result['copyright_evidence'])} copyright items")
                             for copyright_item in scan_result['copyright_evidence']:
                                 statement = copyright_item.get('statement', '')
-                                print(f"DEBUG: Processing copyright: statement='{statement}'", file=sys.stderr)
+                                logger.debug(f"DEBUG: Processing copyright: statement='{statement}'")
                                 if statement and statement not in seen_copyrights:
                                     seen_copyrights.add(statement)
                                     copyright_info = {
@@ -293,7 +293,7 @@ class OssliliSubprocessDetector:
                                         "confidence": copyright_item.get('confidence', 1.0)
                                     }
                                     copyrights.append(copyright_info)
-                                    print(f"DEBUG: Added copyright: {copyright_info}", file=sys.stderr)
+                                    logger.debug(f"DEBUG: Added copyright: {copyright_info}")
 
             # TODO: OSSlili v1.5.0 doesn't detect "Copyright (c)" format - FIXED in v1.5.1
             # Issue filed: https://github.com/oscarvalenzuelab/osslili/issues/32

--- a/tests/e2e/test_end_to_end.py
+++ b/tests/e2e/test_end_to_end.py
@@ -195,9 +195,12 @@ Implementation-Version: 1.0.0
         result = runner.invoke(cli, ['detect', str(file_path), '--verbose'])
         
         assert result.exit_code == 0
-        assert "File: test.whl" in result.output
-        assert "Size:" in result.output
-        assert "Type: python_wheel" in result.output
+        assert "File: test.whl" in result.stderr
+        assert "Size:" in result.stderr
+        # stdout carries the detected type and nothing else, so
+        # `upmex detect -v x` stays usable in a pipeline.
+        assert result.stdout.strip()
+        assert "python_wheel" in result.stdout
     
     def test_license_command(self, tmp_path):
         """Test license extraction command."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -71,9 +71,12 @@ License: MIT
         """Test detect command with verbose output."""
         result = runner.invoke(cli, ['detect', '-v', sample_package])
         assert result.exit_code == 0
-        assert 'File:' in result.output
-        assert 'Size:' in result.output
-        assert 'Type: python_wheel' in result.output
+        # The type is what a caller reads off this command, so it stays on
+        # stdout at either verbosity; the commentary goes beside it. The old
+        # "Type: ..." line duplicated the value on the wrong stream.
+        assert result.stdout.strip() == 'python_wheel'
+        assert 'File:' in result.stderr
+        assert 'Size:' in result.stderr
     
     def test_detect_nonexistent_file(self, runner):
         """Test detect command with non-existent file."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -23,7 +23,9 @@ class TestConfig:
         """Test getting nested configuration values."""
         config = Config()
         
-        assert config.get("api.clearlydefined.base_url") == "https://api.clearlydefined.io/v1"
+        # ClearlyDefined serves /definitions directly and answers 404 for a
+        # /v1 prefix, so the configured value has to be the bare host.
+        assert config.get("api.clearlydefined.base_url") == "https://api.clearlydefined.io"
         assert config.get("license_detection.confidence_threshold") == 0.85
         assert config.get("non.existent.key", "default") == "default"
     

--- a/tests/unit/test_stdout_is_the_record.py
+++ b/tests/unit/test_stdout_is_the_record.py
@@ -1,0 +1,916 @@
+"""What goes on stdout, and what the configuration is allowed to change.
+
+Extractors reported problems with print(), which writes to standard output, so
+a damaged archive put a diagnostic line ahead of the JSON record on the same
+stream. `upmex extract broken.whl | jq .` then failed to parse, which is
+exactly the artifact a compliance scan needs to survive rather than choke on.
+Nothing was written to stderr at all.
+
+Separately, the configuration declared enabled, base_url, timeout and api_key
+for ClearlyDefined and the client read none of them. The base_url it held
+carried a /v1 prefix that ClearlyDefined answers 404 for, so wiring it up as
+written would have broken the integration rather than fixed it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from upmex.api.clearlydefined import ClearlyDefinedAPI
+from upmex.config import Config
+from upmex.core.models import PackageType
+
+
+class TestStdoutCarriesOnlyTheRecord:
+    def test_a_damaged_archive_still_yields_parseable_json(self, tmp_path):
+        broken = tmp_path / "broken.whl"
+        broken.write_bytes(b"not a zip")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "upmex.cli", "extract", str(broken)],
+            capture_output=True, text=True,
+        )
+
+        json.loads(result.stdout)  # raises if anything else got in the way
+
+    def test_the_diagnostic_goes_to_stderr(self, tmp_path):
+        broken = tmp_path / "broken.whl"
+        broken.write_bytes(b"not a zip")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "upmex.cli", "extract", str(broken)],
+            capture_output=True, text=True,
+        )
+
+        assert "not a zip file" in result.stderr
+        assert "not a zip file" not in result.stdout
+
+    def test_the_record_is_still_complete(self, tmp_path):
+        """Routing the noise away must not take the answer with it."""
+        broken = tmp_path / "broken.whl"
+        broken.write_bytes(b"not a zip")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "upmex.cli", "extract", str(broken)],
+            capture_output=True, text=True,
+        )
+
+        document = json.loads(result.stdout)
+        assert document["package"]["type"] == "python_wheel"
+        assert "file_info" in document
+
+    def test_a_good_package_is_unaffected(self, tmp_path):
+        """The ordinary path had no diagnostic on it and must stay quiet."""
+        import zipfile
+
+        wheel = tmp_path / "p-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as archive:
+            archive.writestr(
+                "p-1.0.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: p\nVersion: 1.0.0\nLicense: MIT\n",
+            )
+
+        result = subprocess.run(
+            [sys.executable, "-m", "upmex.cli", "extract", str(wheel)],
+            capture_output=True, text=True,
+        )
+
+        document = json.loads(result.stdout)
+        assert document["package"]["name"] == "p"
+
+
+class TestNoDiagnosticIsLeftOnStdout:
+    def test_nothing_outside_the_cli_prints(self):
+        """The CLI writes the record. Everything else reports through
+        logging, which goes to stderr, and which --quiet and --verbose reach.
+        """
+        root = Path(__file__).resolve().parents[2] / "src" / "upmex"
+        offenders = []
+        for path in root.rglob("*.py"):
+            if path.name == "cli.py":
+                continue
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue
+                if stripped.startswith("print(") or " print(" in stripped:
+                    offenders.append(f"{path.name}:{number}: {stripped}")
+        assert not offenders, offenders
+
+
+class TestTheClearlyDefinedSettingsAreRead:
+    def test_the_base_url_has_no_version_prefix(self):
+        """/v1 is a 404. The service serves /definitions from the host."""
+        assert Config().get("api.clearlydefined.base_url") == (
+            "https://api.clearlydefined.io"
+        )
+
+    def test_the_shipped_config_file_agrees_with_the_defaults(self):
+        """config/default.json is not what Config() reads, so the two can
+        drift, and a reader following the file would configure the 404."""
+        shipped = json.loads(
+            (Path(__file__).resolve().parents[2] / "config" / "default.json")
+            .read_text()
+        )
+
+        for setting in ("base_url", "enabled", "timeout", "api_key"):
+            assert shipped["api"]["clearlydefined"][setting] == Config().get(
+                f"api.clearlydefined.{setting}"
+            ), setting
+
+    def test_the_client_uses_the_configured_base_url(self):
+        class Configured:
+            def get(self, key, default=None):
+                if key == "api.clearlydefined.base_url":
+                    return "https://mirror.example.invalid/"
+                return default
+
+        client = ClearlyDefinedAPI(config=Configured())
+
+        assert client.base_url == "https://mirror.example.invalid"
+
+    def test_the_client_uses_the_configured_timeout(self):
+        class Configured:
+            def get(self, key, default=None):
+                return 5 if key == "api.clearlydefined.timeout" else default
+
+        assert ClearlyDefinedAPI(config=Configured()).timeout == 5
+
+    def test_the_client_uses_the_configured_key(self):
+        class Configured:
+            def get(self, key, default=None):
+                return "abc" if key == "api.clearlydefined.api_key" else default
+
+        client = ClearlyDefinedAPI(config=Configured())
+
+        assert client.api_key == "abc"
+        assert client.headers["Authorization"] == "Bearer abc"
+
+    def test_a_passed_key_wins_over_the_configured_one(self):
+        class Configured:
+            def get(self, key, default=None):
+                return "from-config" if key.endswith("api_key") else default
+
+        assert ClearlyDefinedAPI("passed", Configured()).api_key == "passed"
+
+    def test_no_key_sends_no_authorization(self):
+        class Configured:
+            def get(self, key, default=None):
+                return default
+
+        assert ClearlyDefinedAPI(config=Configured()).headers == {}
+
+
+class TestDisabledMeansDisabled:
+    """Setting enabled to false disabled nothing, so a deployment that asked
+    not to reach ClearlyDefined reached it anyway."""
+
+    class Off:
+        def get(self, key, default=None):
+            return False if key.endswith("enabled") else default
+
+    def test_no_request_is_made(self, monkeypatch):
+        """Recorded rather than raised: get_definition catches everything, so
+        an exception here would be swallowed and the test would pass whether
+        the request happened or not."""
+        import upmex.api.clearlydefined as module
+
+        attempts = []
+
+        def record(*args, **kwargs):
+            attempts.append(args[0] if args else kwargs.get("url"))
+            raise RuntimeError("no network in this test")
+
+        monkeypatch.setattr(module.requests, "get", record)
+
+        result = ClearlyDefinedAPI(config=self.Off()).get_definition(
+            PackageType.NPM, None, "express", "4.18.2"
+        )
+
+        assert attempts == [], attempts
+        assert result is None
+
+    def test_enabled_does_make_the_request(self, monkeypatch):
+        """The other half: the guard must not disable everything."""
+        import upmex.api.clearlydefined as module
+
+        attempts = []
+
+        def record(*args, **kwargs):
+            attempts.append(args[0] if args else kwargs.get("url"))
+            raise RuntimeError("no network in this test")
+
+        monkeypatch.setattr(module.requests, "get", record)
+
+        class On:
+            def get(self, key, default=None):
+                return True if key.endswith("enabled") else default
+
+        ClearlyDefinedAPI(config=On()).get_definition(
+            PackageType.NPM, None, "express", "4.18.2"
+        )
+
+        assert attempts, "the request was never attempted"
+
+    def test_enabled_by_default(self):
+        class Silent:
+            def get(self, key, default=None):
+                return default
+
+        assert ClearlyDefinedAPI(config=Silent()).enabled is True
+
+
+class TestVerboseKeepsStdoutClean:
+    """The record shares the stream with whatever -v prints, so a diagnostic
+    there breaks the pipe exactly as the extractor's own did."""
+
+    def _extract(self, tmp_path, *flags):
+        broken = tmp_path / "broken.whl"
+        broken.write_bytes(b"not a zip")
+        return subprocess.run(
+            [sys.executable, "-m", "upmex.cli", *flags, "extract", str(broken)],
+            capture_output=True, text=True,
+        )
+
+    def test_verbose_output_still_parses(self, tmp_path):
+        result = self._extract(tmp_path, "-v")
+
+        json.loads(result.stdout)
+
+    def test_the_verbose_lines_are_on_stderr(self, tmp_path):
+        result = self._extract(tmp_path, "-v")
+
+        assert "Extracting metadata from" in result.stderr
+        assert "Extracting metadata from" not in result.stdout
+
+
+class TestEnrichmentDoesNotDependOnVerbosity:
+    """The whole ClearlyDefined block sat inside `if verbose:`, so asking for
+    enrichment and not asking for chatter got no enrichment at all:
+
+        upmex extract x --api clearlydefined       -> nothing fetched
+        upmex extract x --api clearlydefined -v    -> fetched
+    """
+
+    def _wheel(self, tmp_path):
+        import zipfile
+
+        wheel = tmp_path / "p-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as archive:
+            archive.writestr(
+                "p-1.0.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: p\nVersion: 1.0.0\n",
+            )
+        return wheel
+
+    def _run(self, tmp_path, monkeypatch, *flags):
+        from click.testing import CliRunner
+
+        import upmex.api.clearlydefined as module
+        from upmex.cli import cli
+
+        built = []
+
+        class Recorder:
+            def __init__(self, api_key=None, config=None):
+                built.append(("built", config))
+
+            def get_definition(self, **kwargs):
+                built.append(("queried", kwargs.get("name")))
+                return None
+
+        monkeypatch.setattr(module, "ClearlyDefinedAPI", Recorder)
+        CliRunner().invoke(
+            cli,
+            [*flags, "extract", str(self._wheel(tmp_path)), "--api", "clearlydefined"],
+        )
+        return built
+
+    def test_it_happens_without_verbose(self, tmp_path, monkeypatch):
+        """Constructed and actually asked: building a client and never
+        querying it would look the same from the outside."""
+        events = self._run(tmp_path, monkeypatch)
+
+        assert ("queried", "p") in events, events
+
+    def test_it_still_happens_with_verbose(self, tmp_path, monkeypatch):
+        events = self._run(tmp_path, monkeypatch, "-v")
+
+        assert ("queried", "p") in events, events
+
+    def test_the_command_config_is_what_reaches_it(self, tmp_path, monkeypatch):
+        """The Config the command holds, not a fresh default one built inside
+        the client. It is the dict form, because that is what --config
+        produced and what the command passes on."""
+        events = self._run(tmp_path, monkeypatch)
+
+        built = [config for kind, config in events if kind == "built"]
+        assert built, events
+        assert built[0] is not None
+        # Reaches the settings the command was configured with.
+        from upmex.config import setting
+
+        assert setting(built[0], "api.clearlydefined.base_url", None) == (
+            "https://api.clearlydefined.io"
+        )
+
+
+class TestTheClientReadsEitherConfigShape:
+    """The CLI holds a Config, whose get understands a dotted key. The
+    extractors are handed what to_dict() produced, which is a plain nested
+    dict and answers the same key with the default."""
+
+    def test_a_plain_nested_dict_is_read(self):
+        settings = {"api": {"clearlydefined": {"timeout": 7, "enabled": False}}}
+
+        client = ClearlyDefinedAPI(config=settings)
+
+        assert client.timeout == 7
+        assert client.enabled is False
+
+    def test_a_config_object_is_read(self):
+        assert ClearlyDefinedAPI(config=Config()).timeout == 30
+
+    def test_a_dict_missing_the_section_falls_back(self):
+        client = ClearlyDefinedAPI(config={"api": {}})
+
+        assert client.enabled is True
+        assert client.base_url == "https://api.clearlydefined.io"
+
+    def test_every_construction_site_passes_one(self):
+        """Building the client with no config makes it read the defaults,
+        whatever the caller asked for on the command line."""
+        root = Path(__file__).resolve().parents[2] / "src" / "upmex"
+        bare = []
+        for path in root.rglob("*.py"):
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                if "ClearlyDefinedAPI()" in line:
+                    bare.append(f"{path.name}:{number}")
+        assert not bare, bare
+
+
+class TestOneConfigDoesNotChangeAnother:
+    """DEFAULT_CONFIG was shared by reference, so set() wrote into it and
+    every later Config, and every default-constructed client, saw the change
+    for the life of the process."""
+
+    def test_setting_one_leaves_the_next_alone(self):
+        changed = Config()
+        changed.set("api.clearlydefined.enabled", False)
+
+        assert Config().get("api.clearlydefined.enabled") is True
+
+    def test_and_leaves_the_class_default_alone(self):
+        changed = Config()
+        changed.set("api.clearlydefined.timeout", 999)
+
+        assert Config.DEFAULT_CONFIG["api"]["clearlydefined"]["timeout"] != 999
+
+    def test_the_change_still_applies_to_the_one_that_made_it(self):
+        changed = Config()
+        changed.set("api.clearlydefined.timeout", 999)
+
+        assert changed.get("api.clearlydefined.timeout") == 999
+
+
+class TestTheDebugLinesStillSayAnything:
+    """The print-to-logger conversion dropped the f prefix on interpolated
+    lines, so they logged the braces rather than the values."""
+
+    def test_no_debug_line_logs_a_literal_brace(self):
+        root = Path(__file__).resolve().parents[2] / "src" / "upmex"
+        offenders = []
+        for path in root.rglob("*.py"):
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                stripped = line.strip()
+                if not stripped.startswith("logger."):
+                    continue
+                if '("' in stripped and "{" in stripped and 'f"' not in stripped:
+                    offenders.append(f"{path.name}:{number}: {stripped}")
+        assert not offenders, offenders
+
+
+class TestEveryApiPathKeepsStdoutClean:
+    """The record shares the stream with every diagnostic the command writes,
+    so one line on the wrong stream breaks the pipe. -v without --api was the
+    only case covered, and each --api branch had its own lines."""
+
+    def _wheel(self, tmp_path):
+        import zipfile
+
+        wheel = tmp_path / "p-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as archive:
+            archive.writestr(
+                "p-1.0.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: p\nVersion: 1.0.0\nLicense: MIT\n",
+            )
+        return wheel
+
+    @pytest.mark.parametrize(
+        "flags",
+        [
+            [],
+            ["-v"],
+            ["-v", "--registry"],
+        ],
+    )
+    def test_stdout_is_parseable(self, tmp_path, flags):
+        result = subprocess.run(
+            [sys.executable, "-m", "upmex.cli", *[f for f in flags if f == "-v"],
+             "extract", str(self._wheel(tmp_path)),
+             *[f for f in flags if f != "-v"]],
+            capture_output=True, text=True,
+        )
+
+        json.loads(result.stdout)
+
+    def test_only_the_record_is_written_to_stdout(self):
+        """Every other echo in the command goes to stderr. Checked on the
+        source because reaching each branch needs the network."""
+        import inspect
+
+        from upmex import cli
+
+        source = inspect.getsource(cli.extract.callback)
+        loose = [
+            line.strip()
+            for line in source.splitlines()
+            if "click.echo(" in line and "err=True" not in line
+        ]
+
+        assert loose == ["click.echo(output_text)"], loose
+
+    def test_writing_to_a_file_says_so_on_stderr(self, tmp_path):
+        out = tmp_path / "record.json"
+        result = subprocess.run(
+            [sys.executable, "-m", "upmex.cli", "extract",
+             str(self._wheel(tmp_path)), "-o", str(out)],
+            capture_output=True, text=True,
+        )
+
+        assert "Output written to" in result.stderr
+        assert "Output written to" not in result.stdout
+        json.loads(out.read_text())
+
+
+class TestTheEcosystemsSettingsAreReadToo:
+    """The same defect, in the sibling client: the configuration declared
+    enabled, base_url, timeout and api_key and none of them was read. Its
+    configured base_url does not resolve at all, so wiring it up as written
+    would have broken the integration outright."""
+
+    def test_the_base_url_resolves(self):
+        """packages.ecosyste.ms/api/v1 answers; api.ecosyste.ms/v1 does not."""
+        assert Config().get("api.ecosystems.base_url") == (
+            "https://packages.ecosyste.ms/api/v1"
+        )
+
+    def test_the_client_reads_the_configured_settings(self):
+        from upmex.api.ecosystems import EcosystemsAPI
+
+        settings = {
+            "api": {"ecosystems": {"timeout": 3, "api_key": "tok", "enabled": True}}
+        }
+        client = EcosystemsAPI(config=settings)
+
+        assert client.timeout == 3
+        assert client.headers["Authorization"] == "Bearer tok"
+
+    def test_disabled_makes_no_request(self, monkeypatch):
+        import upmex.api.ecosystems as module
+        from upmex.api.ecosystems import EcosystemsAPI
+        from upmex.core.models import PackageType
+
+        attempts = []
+
+        def record(*args, **kwargs):
+            attempts.append(args[0] if args else kwargs.get("url"))
+            raise RuntimeError("no network in this test")
+
+        monkeypatch.setattr(module.requests, "get", record)
+        off = {"api": {"ecosystems": {"enabled": False}}}
+
+        assert EcosystemsAPI(config=off).get_package_info(
+            PackageType.NPM, "express"
+        ) is None
+        assert attempts == []
+
+    def test_every_construction_site_passes_a_config(self):
+        root = Path(__file__).resolve().parents[2] / "src" / "upmex"
+        bare = []
+        for path in root.rglob("*.py"):
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                if "EcosystemsAPI()" in line:
+                    bare.append(f"{path.name}:{number}")
+        assert not bare, bare
+
+    def test_the_shipped_file_agrees_here_too(self):
+        shipped = json.loads(
+            (Path(__file__).resolve().parents[2] / "config" / "default.json")
+            .read_text()
+        )
+
+        for name in ("base_url", "enabled", "timeout", "api_key"):
+            assert shipped["api"]["ecosystems"][name] == Config().get(
+                f"api.ecosystems.{name}"
+            ), name
+
+
+class TestDetectKeepsStdoutToTheType:
+    """`upmex detect -v x` put File and Size on stdout alongside a "Type: ..."
+    line, so the value a caller reads was wrapped in prose at one verbosity
+    and bare at the other."""
+
+    def _run(self, tmp_path, *flags):
+        package = tmp_path / "p-1.0.0-py3-none-any.whl"
+        package.write_bytes(b"anything")
+        return subprocess.run(
+            [sys.executable, "-m", "upmex.cli", "detect", *flags, str(package)],
+            capture_output=True, text=True,
+        )
+
+    def test_the_type_is_the_same_at_either_verbosity(self, tmp_path):
+        plain = self._run(tmp_path).stdout.strip()
+        verbose = self._run(tmp_path, "-v").stdout.strip()
+
+        assert plain == verbose
+        assert plain
+
+    def test_the_commentary_is_on_stderr(self, tmp_path):
+        result = self._run(tmp_path, "-v")
+
+        assert "File:" in result.stderr
+        assert "File:" not in result.stdout
+        assert "Size:" not in result.stdout
+
+
+class TestTheDocumentedEnvironmentKeysReachSomething:
+    """The README tells a user to export these. Neither was mapped, so
+    exporting one set a key nothing ever read."""
+
+    @pytest.mark.parametrize(
+        "variable,key",
+        [
+            ("PME_CLEARLYDEFINED_API_KEY", "api.clearlydefined.api_key"),
+            ("PME_ECOSYSTEMS_API_KEY", "api.ecosystems.api_key"),
+            ("PME_PURLDB_API_KEY", "api.purldb.api_key"),
+            ("PME_VULNERABLECODE_API_KEY", "api.vulnerablecode.api_key"),
+        ],
+    )
+    def test_each_one_is_mapped(self, variable, key, monkeypatch):
+        monkeypatch.setenv(variable, "a-token")
+
+        assert Config().get(key) == "a-token"
+
+    def test_every_key_the_readme_documents_is_mapped(self):
+        """So a variable added to the documentation and not to the mapping is
+        noticed rather than silently doing nothing."""
+        import re
+
+        readme = (Path(__file__).resolve().parents[2] / "README.md").read_text()
+        documented = set(re.findall(r"\bPME_[A-Z_]+\b", readme))
+        mapped = set(Config.ENV_VAR_MAPPING)
+
+        assert documented <= mapped, sorted(documented - mapped)
+
+
+class TestEveryDeclaredApiClientReadsItsSettings:
+    """Adding a config section for a client that does not read it is the
+    defect this whole change is about, so the rule is checked for all four
+    rather than for the two the issue named."""
+
+    CLIENTS = {
+        "clearlydefined": "upmex.api.clearlydefined.ClearlyDefinedAPI",
+        "ecosystems": "upmex.api.ecosystems.EcosystemsAPI",
+        "purldb": "upmex.api.purldb.PurlDBAPI",
+        "vulnerablecode": "upmex.api.vulnerablecode.VulnerableCodeAPI",
+    }
+
+    def _client(self, dotted, settings):
+        import importlib
+
+        module, name = dotted.rsplit(".", 1)
+        return getattr(importlib.import_module(module), name)(config=settings)
+
+    @pytest.mark.parametrize("section,dotted", sorted(CLIENTS.items()))
+    def test_the_timeout_is_read(self, section, dotted):
+        client = self._client(dotted, {"api": {section: {"timeout": 3}}})
+
+        assert client.timeout == 3
+
+    @pytest.mark.parametrize("section,dotted", sorted(CLIENTS.items()))
+    def test_the_key_is_read(self, section, dotted):
+        client = self._client(dotted, {"api": {section: {"api_key": "tok"}}})
+
+        assert client.api_key == "tok"
+        assert "tok" in str(client.headers)
+
+    @pytest.mark.parametrize("section,dotted", sorted(CLIENTS.items()))
+    def test_the_base_url_is_read(self, section, dotted):
+        client = self._client(
+            dotted, {"api": {section: {"base_url": "https://mirror.invalid/"}}}
+        )
+
+        assert client.base_url == "https://mirror.invalid"
+
+    @pytest.mark.parametrize("section,dotted", sorted(CLIENTS.items()))
+    def test_disabled_is_honoured(self, section, dotted):
+        client = self._client(dotted, {"api": {section: {"enabled": False}}})
+
+        assert client.enabled is False
+
+    @pytest.mark.parametrize("section", sorted(CLIENTS))
+    def test_the_default_url_is_the_one_the_client_builds_on(self, section):
+        """The clients append their own /api/... path, so a setting carrying
+        one produces /api/api/... . Checked against what the client uses when
+        nothing is configured."""
+        client = self._client(self.CLIENTS[section], {})
+
+        assert Config().get(f"api.{section}.base_url") == client.base_url
+
+    @pytest.mark.parametrize("section", sorted(CLIENTS))
+    def test_the_shipped_file_carries_the_section(self, section):
+        shipped = json.loads(
+            (Path(__file__).resolve().parents[2] / "config" / "default.json")
+            .read_text()
+        )
+
+        for name in ("base_url", "enabled", "timeout", "api_key"):
+            assert shipped["api"][section][name] == Config().get(
+                f"api.{section}.{name}"
+            ), f"{section}.{name}"
+
+    def test_no_client_is_built_without_a_config(self):
+        """A bare construction reads the defaults whatever the caller asked."""
+        root = Path(__file__).resolve().parents[2] / "src" / "upmex"
+        bare = []
+        for path in root.rglob("*.py"):
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                for name in ("ClearlyDefinedAPI", "EcosystemsAPI",
+                             "PurlDBAPI", "VulnerableCodeAPI"):
+                    if f"{name}()" in line:
+                        bare.append(f"{path.name}:{number}")
+        assert not bare, bare
+
+    @pytest.mark.parametrize(
+        "section,dotted,call",
+        [
+            ("clearlydefined", "upmex.api.clearlydefined.ClearlyDefinedAPI",
+             lambda c: c.get_definition(
+                 __import__("upmex.core.models", fromlist=["PackageType"])
+                 .PackageType.NPM, None, "express", "4.18.2")),
+            ("ecosystems", "upmex.api.ecosystems.EcosystemsAPI",
+             lambda c: c.get_package_info(
+                 __import__("upmex.core.models", fromlist=["PackageType"])
+                 .PackageType.NPM, "express")),
+            ("purldb", "upmex.api.purldb.PurlDBAPI",
+             lambda c: c.get_package_by_purl("pkg:npm/express@4.18.2")),
+            ("vulnerablecode", "upmex.api.vulnerablecode.VulnerableCodeAPI",
+             lambda c: c.get_vulnerabilities_by_purl("pkg:npm/express@4.18.2")),
+        ],
+    )
+    def test_disabled_makes_no_request_even_with_a_key(
+        self, section, dotted, call, monkeypatch
+    ):
+        """With a key configured, nothing else short-circuits, so this is the
+        case only the enabled guard can stop. Without one, VulnerableCode
+        returns early anyway and the guard is untested."""
+        import importlib
+
+        module_name, name = dotted.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        attempts = []
+
+        def record(*args, **kwargs):
+            attempts.append(args[0] if args else kwargs.get("url"))
+            raise RuntimeError("no network in this test")
+
+        monkeypatch.setattr(module.requests, "get", record)
+        client = getattr(module, name)(
+            config={"api": {section: {"enabled": False, "api_key": "tok"}}}
+        )
+
+        assert call(client) is None
+        assert attempts == [], attempts
+
+    @pytest.mark.parametrize(
+        "section,dotted,call",
+        [
+            ("purldb", "upmex.api.purldb.PurlDBAPI",
+             lambda c: c.get_package_by_purl("pkg:npm/express@4.18.2")),
+            ("vulnerablecode", "upmex.api.vulnerablecode.VulnerableCodeAPI",
+             lambda c: c.get_vulnerabilities_by_purl("pkg:npm/express@4.18.2")),
+        ],
+    )
+    def test_enabled_does_reach_the_network(
+        self, section, dotted, call, monkeypatch
+    ):
+        """The other half: the guard must not disable everything."""
+        import importlib
+
+        module_name, name = dotted.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        attempts = []
+
+        def record(*args, **kwargs):
+            attempts.append(args[0] if args else kwargs.get("url"))
+            raise RuntimeError("no network in this test")
+
+        monkeypatch.setattr(module.requests, "get", record)
+        client = getattr(module, name)(
+            config={"api": {section: {"enabled": True, "api_key": "tok"}}}
+        )
+        call(client)
+
+        assert attempts, "the request was never attempted"
+
+
+def _npm_package(tmp_path):
+    """A real .tgz on disk, so the CLI runs its normal extract path."""
+    import tarfile
+
+    src = tmp_path / "package"
+    src.mkdir(exist_ok=True)
+    (src / "package.json").write_text(
+        json.dumps({"name": "express", "version": "4.18.2", "license": "MIT"})
+    )
+    pkg = tmp_path / "express.tgz"
+    with tarfile.open(pkg, "w:gz") as tar:
+        tar.add(src / "package.json", arcname="package/package.json")
+    return pkg
+
+
+class TestDisabledStopsTheRealEntryPoint:
+    """The guard has to sit on the method the CLI calls, not on a sibling.
+
+    An earlier version guarded PurlDB.get_package_by_purl while the CLI calls
+    get_package_info, so `enabled: false` was ignored in production and the
+    unit test still passed. These drive the CLI itself.
+    """
+
+    @pytest.mark.parametrize(
+        "api,section",
+        [
+            ("clearlydefined", "clearlydefined"),
+            ("ecosystems", "ecosystems"),
+            ("purldb", "purldb"),
+            ("vulnerablecode", "vulnerablecode"),
+        ],
+    )
+    def test_cli_honours_disabled(self, api, section, tmp_path, monkeypatch):
+        import json
+
+        from click.testing import CliRunner
+
+        from upmex import cli as cli_module
+        from upmex.api import (
+            clearlydefined as cd_mod,
+            ecosystems as eco_mod,
+            purldb as purldb_mod,
+            vulnerablecode as vc_mod,
+        )
+
+        attempts = []
+
+        def record(*args, **kwargs):
+            attempts.append(args[0] if args else kwargs.get("url"))
+            raise RuntimeError("no network in this test")
+
+        for mod in (cd_mod, eco_mod, purldb_mod, vc_mod):
+            monkeypatch.setattr(mod.requests, "get", record)
+
+        cfg = tmp_path / "upmex.json"
+        cfg.write_text(
+            json.dumps({"api": {section: {"enabled": False, "api_key": "tok"}}})
+        )
+        pkg = _npm_package(tmp_path)
+
+        result = CliRunner().invoke(
+            cli_module.cli,
+            ["--config", str(cfg), "extract", str(pkg), "--api", api],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert attempts == [], attempts
+
+    @pytest.mark.parametrize(
+        "api,section",
+        [
+            ("clearlydefined", "clearlydefined"),
+            ("ecosystems", "ecosystems"),
+            ("purldb", "purldb"),
+            ("vulnerablecode", "vulnerablecode"),
+        ],
+    )
+    def test_cli_enabled_still_reaches_the_network(
+        self, api, section, tmp_path, monkeypatch
+    ):
+        """The other half: the guard must not disable everything."""
+        import json
+
+        from click.testing import CliRunner
+
+        from upmex import cli as cli_module
+        from upmex.api import (
+            clearlydefined as cd_mod,
+            ecosystems as eco_mod,
+            purldb as purldb_mod,
+            vulnerablecode as vc_mod,
+        )
+
+        attempts = []
+
+        def record(*args, **kwargs):
+            attempts.append(args[0] if args else kwargs.get("url"))
+            raise RuntimeError("no network in this test")
+
+        for mod in (cd_mod, eco_mod, purldb_mod, vc_mod):
+            monkeypatch.setattr(mod.requests, "get", record)
+
+        cfg = tmp_path / "upmex.json"
+        cfg.write_text(
+            json.dumps({"api": {section: {"enabled": True, "api_key": "tok"}}})
+        )
+        pkg = _npm_package(tmp_path)
+
+        CliRunner().invoke(
+            cli_module.cli,
+            ["--config", str(cfg), "extract", str(pkg), "--api", api],
+        )
+
+        assert attempts, f"{api} never attempted a request"
+
+
+class TestLegacyTopLevelApiKey:
+    """A config file predating the api.* sections put the key at the top level.
+
+    The CLI still reads it. It has to still reach the client, or upgrading
+    upmex silently turns a working VulnerableCode setup off.
+    """
+
+    def test_top_level_vulnerablecode_key_still_authenticates(
+        self, tmp_path, monkeypatch
+    ):
+        from click.testing import CliRunner
+
+        from upmex import cli as cli_module
+        from upmex.api import vulnerablecode as vc_mod
+
+        seen = []
+
+        def record(*args, **kwargs):
+            seen.append(kwargs.get("headers") or {})
+            raise RuntimeError("no network in this test")
+
+        monkeypatch.setattr(vc_mod.requests, "get", record)
+
+        cfg = tmp_path / "upmex.json"
+        cfg.write_text(json.dumps({"vulnerablecode_api_key": "legacy-tok"}))
+        pkg = _npm_package(tmp_path)
+
+        CliRunner().invoke(
+            cli_module.cli,
+            ["--config", str(cfg), "extract", str(pkg), "--api", "vulnerablecode"],
+        )
+
+        assert seen, "no request attempted, so the key never took effect"
+        assert seen[0].get("Authorization") == "Token legacy-tok", seen[0]
+
+    def test_top_level_key_wins_over_the_nested_one(self, tmp_path, monkeypatch):
+        """An explicit argument has always beaten configuration."""
+        from click.testing import CliRunner
+
+        from upmex import cli as cli_module
+        from upmex.api import vulnerablecode as vc_mod
+
+        seen = []
+
+        def record(*args, **kwargs):
+            seen.append(kwargs.get("headers") or {})
+            raise RuntimeError("no network in this test")
+
+        monkeypatch.setattr(vc_mod.requests, "get", record)
+
+        cfg = tmp_path / "upmex.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "vulnerablecode_api_key": "legacy-tok",
+                    "api": {"vulnerablecode": {"api_key": "nested-tok"}},
+                }
+            )
+        )
+        pkg = _npm_package(tmp_path)
+
+        CliRunner().invoke(
+            cli_module.cli,
+            ["--config", str(cfg), "extract", str(pkg), "--api", "vulnerablecode"],
+        )
+
+        assert seen, "no request attempted"
+        assert seen[0].get("Authorization") == "Token legacy-tok", seen[0]


### PR DESCRIPTION
Closes #107. Closes #99.

## #107 - the api config was declared and never read

`DEFAULT_CONFIG` declared `api.clearlydefined.enabled`, `base_url`, `timeout` and `api_key`. No client read any of them. Setting them changed `Config()` and nothing else, which reads as a supported control that silently does nothing.

All four clients now take a `config` and read their own section:

| client | enabled | base_url | timeout | api_key |
|---|---|---|---|---|
| clearlydefined | yes | yes | yes | yes |
| ecosystems | yes | yes | yes | yes |
| purldb | yes | yes | yes | yes |
| vulnerablecode | yes | yes | yes | yes |

`purldb` and `vulnerablecode` had no config section at all, so both sections were added and wired in the same change rather than declaring settings nothing reads.

`enabled: false` is a real kill switch, verified end to end:

```
$ echo '{"api":{"purldb":{"enabled":false}}}' > off.json
$ upmex -c off.json extract express.tgz --api purldb
valid json, enrichment: []
```

The guard sits on the method the CLI actually calls. An earlier version guarded `PurlDB.get_package_by_purl` while the CLI calls `get_package_info`, so the setting was ignored in production and the unit test still passed. Each guard is now proved by driving the CLI itself, in both directions: disabled makes no request, enabled still does.

A config file written before the `api.*` sections existed carries the VulnerableCode key at the top level. The CLI still reads it and still passes it through, so upgrading does not silently turn a working setup off.

## #99 - stdout carried more than the output document

Diagnostics were printed to stdout next to the JSON document that is the tool's product. Any consumer piping `upmex` into a parser got a parse error the moment a warning fired.

Every diagnostic now goes to stderr or to the logger. The only remaining stdout write in `extract` is the output document. `print()` calls in the extractors became logger calls for the same reason.

```
$ upmex extract broken.whl | python -c 'import json,sys; json.load(sys.stdin)'
valid
```

## Verification

349 tests pass, 2 skipped. `tests/unit/test_stdout_is_the_record.py` is new.

Every guard and fallback in this change was mutation tested: the guard was removed or inverted and the suite had to fail. Two mutants survived the first pass and were dealt with rather than left. One was a genuine test gap, where a `VulnerableCode` `api_key` check returned before the `enabled` guard, so the test never reached the code it claimed to cover. The other was a redundant second guard on a method that delegates to an already guarded one, which was removed.

Regression sweep against 8 real packages (express, urllib3, click, packaging, requests, flask, react, lodash) plus the plain and `-v` runs across every `--api` choice: unchanged output, valid JSON throughout.

`--api all` records no purldb enrichment because the earlier APIs have already filled every field it would supply, and enrichment is only recorded when a field is actually applied. `--api purldb` alone records it. Not a regression.

## Out of scope

`output.*` and `logging.*` settings are still declared and unread. Same defect, different sections, pre-existing on main, tracked as #110.