### PR TITLE
Judge osslili evidence by what it is, not only by its score

### DIFF
--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -12,6 +12,34 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# osslili scores a match and also says what kind of evidence it is. A score
+# alone is not the whole claim: the same MIT text scores 0.95 on one machine
+# and 0.6 on another, because the similarity backend differs. Gating only on
+# the number made the reported licence depend on where upmex ran.
+#
+# category == "declared" is osslili concluding the file declares this licence,
+# which is a statement about the evidence rather than about how close the text
+# matched. Take it, take an exact identifier match, and take a high score.
+# Everything weaker than that stays out.
+EXACT_DETECTION_METHODS = ('tag', 'spdx_identifier')
+HIGH_CONFIDENCE = 0.95
+
+# Often confused with Apache-2.0, and never right when it appears.
+KNOWN_FALSE_POSITIVES = ('Pixar',)
+
+
+def is_reportable(lic, spdx_id=None):
+    """Whether one piece of osslili evidence is strong enough to report."""
+    spdx_id = spdx_id or lic.get('spdx_id') or lic.get('detected_license')
+    if spdx_id in KNOWN_FALSE_POSITIVES:
+        return False
+    return (
+        lic.get('confidence', 0) >= HIGH_CONFIDENCE
+        or lic.get('detection_method', '') in EXACT_DETECTION_METHODS
+        or lic.get('category') == 'declared'
+    )
+
+
 
 class OssliliSubprocessDetector:
     """License detector using osslili CLI."""
@@ -97,13 +125,7 @@ class OssliliSubprocessDetector:
                                         "match_type": lic.get('match_type'),
                                     }
                                     
-                                    # Include high-confidence matches or tag detections
-                                    detection_method = lic.get('detection_method', '')
-                                    if (lic.get('confidence', 0) >= 0.95 or 
-                                        detection_method in ['tag', 'spdx_identifier']):
-                                        # Skip known false positive: Pixar
-                                        if spdx_id == 'Pixar':
-                                            continue
+                                    if is_reportable(lic, spdx_id):
                                         licenses.append(license_info)
                     elif 'results' in data and data['results']:
                         # Fallback to old format
@@ -129,13 +151,7 @@ class OssliliSubprocessDetector:
                                         "match_type": lic.get('match_type'),
                                     }
                                     
-                                    # Include high-confidence matches or tag detections
-                                    detection_method = lic.get('detection_method', '')
-                                    if (lic.get('confidence', 0) >= 0.95 or 
-                                        detection_method in ['tag', 'spdx_identifier']):
-                                        # Skip known false positive: Pixar
-                                        if lic.get('spdx_id') == 'Pixar':
-                                            continue
+                                    if is_reportable(lic):
                                         licenses.append(license_info)
                         
             finally:
@@ -222,13 +238,7 @@ class OssliliSubprocessDetector:
                                     "match_type": lic.get('match_type'),
                                 }
                                 
-                                # Include high-confidence matches or tag detections
-                                detection_method = lic.get('detection_method', '')
-                                if (lic.get('confidence', 0) >= 0.95 or 
-                                    detection_method in ['tag', 'spdx_identifier']):
-                                    # Skip known false positive: Pixar
-                                    if spdx_id == 'Pixar':
-                                        continue
+                                if is_reportable(lic, spdx_id):
                                     licenses.append(license_info)
                 elif 'results' in data and data['results']:
                     # Fallback to old format
@@ -256,12 +266,7 @@ class OssliliSubprocessDetector:
                                     "match_type": lic.get('match_type'),
                                 }
                                 
-                                # Only include very high-confidence matches
-                                # Filter known false positives
-                                if lic.get('confidence', 0) >= 0.95:
-                                    # Skip known false positive: Pixar (often confused with Apache-2.0)
-                                    if lic.get('spdx_id') == 'Pixar':
-                                        continue
+                                if is_reportable(lic):
                                     licenses.append(license_info)
 
                 # Extract copyrights from scan_results - moved to correct indentation level

--- a/tests/unit/test_osslili_cli_is_reachable.py
+++ b/tests/unit/test_osslili_cli_is_reachable.py
@@ -1,0 +1,86 @@
+"""The text detector shells out to the osslili CLI.
+
+Every other test of that detector patches subprocess.run, so the whole suite
+can pass while the binary is missing, broken or too slow, and every real
+detection silently returns nothing. These run the CLI for real, and say what
+went wrong rather than leaving a bare `assert [] == ['MIT']` behind.
+"""
+
+import shutil
+import subprocess
+
+from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector
+
+MIT_TEXT = """MIT License
+
+Copyright (c) 2024 Example
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT."""
+
+
+def test_the_binary_is_on_path():
+    found = shutil.which("osslili")
+    assert found, (
+        "the osslili CLI is not on PATH, so every text detection returns "
+        "nothing and the failure surfaces as a missing licence"
+    )
+
+
+def test_the_binary_runs(tmp_path):
+    target = tmp_path / "LICENSE"
+    target.write_text(MIT_TEXT)
+
+    result = subprocess.run(
+        ["osslili", "-f", "evidence", str(target)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"osslili exited {result.returncode}\n"
+        f"stdout: {result.stdout[:2000]}\n"
+        f"stderr: {result.stderr[:2000]}"
+    )
+    assert "MIT" in result.stdout, (
+        f"osslili ran but found no MIT in its own output\n"
+        f"stdout: {result.stdout[:2000]}\n"
+        f"stderr: {result.stderr[:2000]}"
+    )
+
+
+def test_the_detector_reads_a_licence_file(tmp_path):
+    """The path the NuGet, npm and Python extractors all take."""
+    detector = OssliliSubprocessDetector()
+    found = detector.detect_from_file("LICENSE", MIT_TEXT)
+
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as t:
+        t.write(MIT_TEXT)
+        probe_path = t.name
+    probe = subprocess.run(
+        ["osslili", "-f", "evidence", probe_path],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert [lic["spdx_id"] for lic in found] == ["MIT"], (
+        f"detector returned {found}\n"
+        f"osslili on PATH: {shutil.which('osslili')}\n"
+        f"probe returncode: {probe.returncode}\n"
+        f"probe stdout: {probe.stdout[:3000]}\n"
+        f"probe stderr: {probe.stderr[:1000]}"
+    )

--- a/tests/unit/test_the_evidence_gate.py
+++ b/tests/unit/test_the_evidence_gate.py
@@ -1,0 +1,117 @@
+"""What upmex keeps out of osslili's evidence, and why.
+
+osslili scores a match and also says what kind of evidence it is. Gating on
+the score alone made the answer depend on the machine: the same MIT text was
+scored 0.95 by one similarity backend and 0.6 by another, so a package came
+back MIT locally and unlicensed in CI. These pin the rule to the evidence
+rather than to the number.
+"""
+
+import json
+from unittest.mock import patch
+
+from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector, is_reportable
+
+MIT_TEXT = "MIT License\n\nPermission is hereby granted, free of charge"
+
+
+def _result(evidence):
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = json.dumps(
+            {"scan_results": [{"license_evidence": evidence, "copyright_evidence": []}]}
+        )
+
+    return Result()
+
+
+# The two scorings of the same file, taken from a real run on each machine.
+LOCAL_SCORING = [
+    {"detected_license": "MIT", "confidence": 0.9, "detection_method": "keyword",
+     "category": "detected", "match_type": "keyword"},
+    {"detected_license": "MIT", "confidence": 0.95, "detection_method": "regex",
+     "category": "declared", "match_type": "documentation"},
+]
+CI_SCORING = [
+    {"detected_license": "MIT", "confidence": 0.9, "detection_method": "keyword",
+     "category": "detected", "match_type": "keyword"},
+    {"detected_license": "MIT", "confidence": 0.6, "detection_method": "regex",
+     "category": "declared", "match_type": "documentation"},
+]
+
+
+class TestTheSameFileGivesTheSameAnswer:
+    def test_the_high_scoring_machine_reports_mit(self):
+        with patch("subprocess.run", return_value=_result(LOCAL_SCORING)):
+            found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+        assert "MIT" in [lic["spdx_id"] for lic in found]
+
+    def test_the_low_scoring_machine_reports_mit_too(self):
+        """This is the one that failed. 0.6 on a declared licence is still MIT."""
+        with patch("subprocess.run", return_value=_result(CI_SCORING)):
+            found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+        assert "MIT" in [lic["spdx_id"] for lic in found]
+
+
+class TestWhatStaysOut:
+    def test_a_weak_detection_is_not_reported(self):
+        """Nothing declared it, nothing matched exactly, the score is low."""
+        assert not is_reportable(
+            {"detected_license": "GPL-3.0", "confidence": 0.6,
+             "detection_method": "keyword", "category": "detected"}
+        )
+
+    def test_a_referenced_licence_is_not_a_declared_one(self):
+        """A file that mentions a licence has not declared it."""
+        assert not is_reportable(
+            {"detected_license": "MIT", "confidence": 0.7,
+             "detection_method": "regex", "category": "referenced"}
+        )
+
+    def test_a_third_party_licence_is_not_a_declared_one(self):
+        assert not is_reportable(
+            {"detected_license": "MIT", "confidence": 0.7,
+             "detection_method": "regex", "category": "third-party"}
+        )
+
+    def test_the_known_false_positive_stays_out_however_it_is_categorised(self):
+        """Pixar is the standard Apache-2.0 confusion, and never right."""
+        assert not is_reportable(
+            {"detected_license": "Pixar", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared"}
+        )
+
+    def test_it_stays_out_of_a_real_scan_too(self):
+        with patch("subprocess.run", return_value=_result([
+            {"detected_license": "Pixar", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared"}
+        ])):
+            found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+        assert found == []
+
+
+class TestWhatStillGetsIn:
+    def test_a_high_score_is_enough_on_its_own(self):
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.97,
+             "detection_method": "keyword", "category": "detected"}
+        )
+
+    def test_an_exact_identifier_is_enough_at_any_score(self):
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.1,
+             "detection_method": "spdx_identifier", "category": "detected"}
+        )
+
+    def test_a_tag_is_enough_at_any_score(self):
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.1,
+             "detection_method": "tag", "category": "detected"}
+        )
+
+    def test_declared_is_enough_at_any_score(self):
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.1,
+             "detection_method": "regex", "category": "declared"}
+        )


### PR DESCRIPTION
main has been red since #109. Three NuGet tests assert that a package declaring MIT comes back MIT, and on the runners it came back with no licence at all.

## Cause

`osslili_subprocess.py` reported a match only when it scored 0.95 or above, or was an exact identifier match. osslili reports a category as well as a score, and the score turns out not to be portable. The same MIT text, same osslili 1.7.5, same input bytes:

| | detection_method | confidence | category |
|---|---|---|---|
| my machine | regex | **0.95** | declared |
| CI runner | regex | **0.6** | declared |
| both | keyword | 0.9 | detected |

So the package came back MIT locally and unlicensed in CI. A licence osslili had already concluded the file *declares* was discarded for scoring 0.6.

## Fix

The gate now accepts evidence osslili categorised as `declared`, alongside the exact identifier match and the high score it already accepted. `declared` is a statement about what the evidence is, not about how closely the text matched, so it does not move with the similarity backend.

What still stays out, each with a test: a keyword guess below the threshold, a `referenced` licence, a `third-party` licence, and the Pixar false positive.

The rule existed in four copies and had already drifted apart, one of them missing the exact-identifier clause. It is one function now.

## The gap that let this through

Every existing test of the text detector patches `subprocess.run`. The suite passed whether or not the real binary worked, so a broken detector surfaced as three unrelated NuGet tests asserting a missing licence, and it took reading osslili's raw output on the runner to see why. `tests/unit/test_osslili_cli_is_reachable.py` runs the CLI for real and reports what went wrong.

`tests/unit/test_the_evidence_gate.py` pins both scorings above, so a machine that scores either way gets the same answer.

## Verification

277 tests pass, 2 skipped, including the three NuGet tests that were failing.

Licences extracted from 8 real packages (express, urllib3, click, packaging, requests, flask, react, lodash) are byte-identical before and after, so the looser gate does not invent licences on real input.