### PR TITLE
Run the osslili we depend on, and stop reading a licence off a document's prose

### DIFF
--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -9,7 +9,7 @@ import json
 import tempfile
 import os
 from typing import List, Dict, Optional, Any
-from pathlib import Path
+from pathlib import Path, PurePath
 
 logger = logging.getLogger(__name__)
 
@@ -44,11 +44,59 @@ REJECTED_CATEGORIES = ('referenced', 'third-party')
 # to be dropped: osslili reports it as package_metadata_file at 0.6.
 WEAK_DECLARED_MATCH_TYPES = ('documentation',)
 
+# A document can talk about any licence, including one it does not carry.
+# osslili's SPDX patterns match prose as well as tags: "licensed under the
+# Apache License, Version 2.0" in a README comes back as detection_method
+# "tag", match_type "spdx_identifier", confidence 1.0, indistinguishable in
+# the evidence record from a real SPDX-License-Identifier line. An MIT package
+# whose README credits a bundled dependency was reported as Apache-2.0.
+#
+# So inside a document, a licence named inside a sentence proves nothing.
+# What still counts is evidence that the document carries the licence, or
+# states it in a line whose whole purpose is to state it. osslili separates
+# those: a real "SPDX-License-Identifier: MIT" or "License: MIT" line comes
+# back as header_tag, while "...is licensed under the Apache License" comes
+# back as spdx_identifier.
+#
+# The cost is deliberate. A document holding a full licence text and nothing
+# else is reported as match_type documentation at a score that depends on the
+# machine, the same shape a partial mention produces, so it is refused with
+# the mentions. A package whose only licence statement is prose in its README
+# and which ships no licence file is not read from that prose.
+DOCUMENT_SUFFIXES = ('.md', '.rst', '.adoc', '.txt')
+CARRIES_LICENCE_TEXT = (
+    'license_file',
+    'license_header',
+    'text_similarity',
+    'exact_hash',
+    'header_tag',
+)
+
+# LICENSE.txt and LICENCE.md are licence files that happen to have a document
+# suffix, and are not documents for this purpose.
+LICENCE_FILE_STEMS = (
+    'license', 'licence', 'licenses', 'licences',
+    'copying', 'copyright', 'notice', 'unlicense',
+)
+
+
+def _reads_as_a_document(source_file):
+    """A file whose subject is prose, not licence text."""
+    if not source_file:
+        return False
+    name = PurePath(str(source_file)).name
+    suffix = PurePath(name).suffix.lower()
+    if suffix not in DOCUMENT_SUFFIXES:
+        return False
+    stem = PurePath(name).stem.lower()
+    return not any(stem.startswith(known) for known in LICENCE_FILE_STEMS)
+
+
 # Often confused with Apache-2.0, and never right when it appears.
 KNOWN_FALSE_POSITIVES = ('Pixar',)
 
 
-def is_reportable(lic, spdx_id=None):
+def is_reportable(lic, spdx_id=None, source_file=None):
     """Whether one piece of osslili evidence is strong enough to report."""
     if spdx_id is None:
         spdx_id = lic.get('detected_license') or lic.get('spdx_id')
@@ -57,6 +105,9 @@ def is_reportable(lic, spdx_id=None):
 
     if lic.get('category') in REJECTED_CATEGORIES:
         return False
+
+    if _reads_as_a_document(source_file or lic.get('file')):
+        return lic.get('match_type') in CARRIES_LICENCE_TEXT
 
     if lic.get('detection_method', '') in EXACT_DETECTION_METHODS:
         return True
@@ -97,7 +148,12 @@ class OssliliSubprocessDetector:
             # directory of our own so nothing collides.
             tmp_dir = tempfile.mkdtemp()
             try:
-                tmp_path = os.path.join(tmp_dir, Path(file_path).name)
+                # '', '.' and '/' have no basename, and '..' is a
+                # directory. Writing to either raises, and the broad except
+                # below would turn that into a silent empty result.
+                tmp_path = os.path.join(
+                    tmp_dir, PurePath(file_path).name.strip('.') or 'content'
+                )
                 with open(tmp_path, 'w') as tmp:
                     tmp.write(content)
 
@@ -157,7 +213,7 @@ class OssliliSubprocessDetector:
                                         "match_type": lic.get('match_type'),
                                     }
                                     
-                                    if is_reportable(lic, spdx_id):
+                                    if is_reportable(lic, spdx_id, file_path):
                                         licenses.append(license_info)
                     elif 'results' in data and data['results']:
                         # Fallback to old format
@@ -183,7 +239,7 @@ class OssliliSubprocessDetector:
                                         "match_type": lic.get('match_type'),
                                     }
                                     
-                                    if is_reportable(lic):
+                                    if is_reportable(lic, source_file=file_path):
                                         licenses.append(license_info)
                         
             finally:
@@ -247,6 +303,14 @@ class OssliliSubprocessDetector:
                             for lic in scan_result['license_evidence']:
                                 # Map detected_license to spdx_id for consistency
                                 spdx_id = lic.get('detected_license', lic.get('spdx_id', 'Unknown'))
+                                # Judge before deduplicating. osslili sorts
+                                # evidence by score, so keying on the first
+                                # record for a (licence, file) pair let a
+                                # rejected one stand in for an acceptable one
+                                # behind it, and which came first depended on
+                                # the machine.
+                                if not is_reportable(lic, spdx_id):
+                                    continue
                                 key = (spdx_id, lic.get('file', 'unknown'))
                                 if key in seen_licenses:
                                     continue
@@ -269,14 +333,15 @@ class OssliliSubprocessDetector:
                                     "match_type": lic.get('match_type'),
                                 }
                                 
-                                if is_reportable(lic, spdx_id):
-                                    licenses.append(license_info)
+                                licenses.append(license_info)
                 elif 'results' in data and data['results']:
                     # Fallback to old format
                     for result_item in data['results']:
                         if 'licenses' in result_item:
                             for lic in result_item['licenses']:
                                 # Create unique key to avoid duplicates
+                                if not is_reportable(lic):
+                                    continue
                                 key = (lic.get('spdx_id'), lic.get('source_file'))
                                 if key in seen_licenses:
                                     continue
@@ -297,8 +362,7 @@ class OssliliSubprocessDetector:
                                     "match_type": lic.get('match_type'),
                                 }
                                 
-                                if is_reportable(lic):
-                                    licenses.append(license_info)
+                                licenses.append(license_info)
 
                 # Extract copyrights from scan_results - moved to correct indentation level
                 # (This was incorrectly nested inside the 'elif results' block)

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -28,7 +28,10 @@ def osslili_command():
     beside_the_interpreter = Path(sys.executable).parent / 'osslili'
     for candidate in (beside_the_interpreter,
                       beside_the_interpreter.with_suffix('.exe')):
-        if candidate.exists():
+        # Existing is not the same as runnable. A directory of that name, or a
+        # file with no execute bit, would be taken and then fail inside the
+        # broad except below, reporting no licence rather than falling back.
+        if candidate.is_file() and os.access(candidate, os.X_OK):
             return str(candidate)
     # Nothing beside the interpreter, so fall back rather than fail outright:
     # upmex still works with osslili installed some other way.

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -4,6 +4,7 @@ License detection using osslili CLI subprocess.
 
 import logging
 import shutil
+import sys
 import subprocess
 import json
 import tempfile
@@ -12,6 +13,26 @@ from typing import List, Dict, Optional, Any
 from pathlib import Path, PurePath
 
 logger = logging.getLogger(__name__)
+
+
+def osslili_command():
+    """The osslili installed alongside upmex, not whichever is on PATH.
+
+    upmex declares osslili as a dependency and then invoked it by bare name,
+    so a different copy earlier on PATH answered instead. On this machine that
+    was 1.6.1 from a system package manager rather than the 1.7.5 in the
+    environment, and the two disagree: the same LICENSE file holding the MIT
+    text comes back MIT from one and JSON from the other. Which licence a
+    package appears to have should not depend on PATH order.
+    """
+    beside_the_interpreter = Path(sys.executable).parent / 'osslili'
+    for candidate in (beside_the_interpreter,
+                      beside_the_interpreter.with_suffix('.exe')):
+        if candidate.exists():
+            return str(candidate)
+    # Nothing beside the interpreter, so fall back rather than fail outright:
+    # upmex still works with osslili installed some other way.
+    return shutil.which('osslili') or 'osslili'
 
 # osslili scores a match and also says what kind of evidence it is: a category
 # (declared, detected, referenced, third-party) and a match_type saying which
@@ -56,41 +77,67 @@ WEAK_DECLARED_MATCH_TYPES = ('documentation',)
 # prose, and its header rule matches "License: X" anywhere in the first thirty
 # lines, mid-sentence included. "It bundles terser, license: BSD-2-Clause, for
 # minification" is reported exactly as a real SPDX-License-Identifier line is.
-# Carrying the text is different, and osslili says so with a match type of its
-# own: a README holding a full MIT licence comes back as text_similarity near
-# 0.98, so the common "licence only in the README" package still resolves.
 #
-# The suffixes are the set osslili itself scans as text. Listing fewer left
-# README.markdown and README.asciidoc outside the rule, where the credit
-# sentence this exists to refuse went straight through.
+# Two kinds of evidence survive that. One identifies the file itself, by name
+# or by hash, and needs no score. The other is a measured similarity against
+# the licence text, which is the one thing a passing mention cannot fake, and
+# it is taken only at the top of osslili's scale.
+#
+# Two match types that sound like they belong here do not.
+#
+# license_header reads as a promise that the file opens with a licence header,
+# and osslili emits it at 0.6 for the lone sentence "the bundled minifier is
+# licensed under the Apache License". Inside a document it is another spelling
+# of a mention.
+#
+# documentation is worse, because its score is not comparable between osslili's
+# two modes. Scanning one file, a mention scores 0.6 and a document carrying
+# the whole licence scores 0.95. Scanning a directory, osslili measures a short
+# window around the word "license" instead, and the same mention also scores
+# 0.95. No threshold separates them in both modes, so it is refused in each.
+#
+# The cost, stated plainly: a package whose only licence statement is prose in
+# its README, with no licence file and nothing declared in its metadata, is
+# read as having no licence when a directory is scanned. Reporting a
+# dependency's licence as the package's own is the worse of the two errors.
+STRUCTURALLY_THE_LICENCE = ('license_file', 'exact_hash')
+CARRIES_LICENCE_TEXT = ('text_similarity',)
+
+# Suffixes osslili scans as text, plus the ones it does not but people write
+# documents in anyway. Anchoring on suffix alone missed README with no suffix
+# at all, where the credit sentence went straight through.
 DOCUMENT_SUFFIXES = (
-    '.md', '.markdown', '.rst', '.adoc', '.asciidoc', '.txt', '.text',
+    '.md', '.markdown', '.mdown', '.rst', '.adoc', '.asciidoc',
+    '.txt', '.text', '.textile', '.org', '.me',
 )
-CARRIES_LICENCE_TEXT = (
-    'license_file',
-    'license_header',
-    'text_similarity',
-    'exact_hash',
+DOCUMENT_STEMS = (
+    'readme', 'install', 'installing', 'changelog', 'changes', 'news',
+    'history', 'authors', 'contributors', 'contributing', 'credits',
+    'thanks', 'acknowledgements', 'acknowledgments', 'todo', 'faq',
+    'security', 'support', 'governance', 'roadmap', 'usage', 'manual',
 )
 
-# LICENSE.txt and LICENCE.md are licence files that happen to have a document
-# suffix, and are not documents for this purpose.
-LICENCE_FILE_STEMS = (
-    'license', 'licence', 'licenses', 'licences',
-    'copying', 'copyright', 'notice', 'unlicense',
-)
+# A licence file is never a document, whatever it is called or suffixed:
+# LICENSE.txt, LICENSE-MIT.txt, MIT-LICENSE.md and COPYING all hold the thing
+# itself. Refusing those would be the far worse failure.
+LICENCE_WORDS = ('license', 'licence', 'copying', 'copyright', 'legal',
+                 'notice', 'unlicense', 'unlicence')
 
 
 def _reads_as_a_document(source_file):
     """A file whose subject is prose, not licence text."""
     if not source_file:
         return False
-    name = PurePath(str(source_file)).name
-    suffix = PurePath(name).suffix.lower()
-    if suffix not in DOCUMENT_SUFFIXES:
-        return False
+    name = PurePath(str(source_file).replace('\\', '/')).name
     stem = PurePath(name).stem.lower()
-    return not any(stem.startswith(known) for known in LICENCE_FILE_STEMS)
+    suffix = PurePath(name).suffix.lower()
+
+    if any(word in stem for word in LICENCE_WORDS):
+        return False
+    if suffix in DOCUMENT_SUFFIXES:
+        return True
+    # No suffix at all, so the name is all there is to go on.
+    return not suffix and stem in DOCUMENT_STEMS
 
 
 # Often confused with Apache-2.0, and never right when it appears.
@@ -109,11 +156,10 @@ def is_reportable(lic, spdx_id=None, source_file=None):
 
     if _reads_as_a_document(
             source_file or lic.get('file') or lic.get('source_file')):
-        # The score matters here too. A partial text match lands in a band
-        # osslili only reports when an optional backend is installed, so
-        # accepting it at any score would put back the machine dependence this
-        # rule exists to remove.
-        return (lic.get('match_type') in CARRIES_LICENCE_TEXT
+        match_type = lic.get('match_type')
+        if match_type in STRUCTURALLY_THE_LICENCE:
+            return True
+        return (match_type in CARRIES_LICENCE_TEXT
                 and lic.get('confidence', 0) >= HIGH_CONFIDENCE)
 
     if lic.get('detection_method', '') in EXACT_DETECTION_METHODS:
@@ -166,7 +212,7 @@ class OssliliSubprocessDetector:
 
                 # Run osslili CLI without similarity threshold for better tag detection
                 result = subprocess.run(
-                    ['osslili', '-f', 'evidence', tmp_path],
+                    [osslili_command(), '-f', 'evidence', tmp_path],
                     capture_output=True,
                     text=True,
                     timeout=10
@@ -273,7 +319,7 @@ class OssliliSubprocessDetector:
         try:
             # Run osslili CLI on directory without similarity threshold for better tag detection
             result = subprocess.run(
-                ['osslili', '-f', 'evidence', '--max-depth', '3', dir_path],
+                [osslili_command(), '-f', 'evidence', '--max-depth', '3', dir_path],
                 capture_output=True,
                 text=True,
                 timeout=30

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -123,6 +123,15 @@ DOCUMENT_STEMS = (
 LICENCE_WORDS = ('license', 'licence', 'copying', 'copyright', 'legal',
                  'notice', 'unlicense', 'unlicence')
 
+# A licence file is often named after the licence and nothing else, and a
+# dual-licensed project ships several: MIT.txt beside APACHE.txt. None of them
+# contains a licence word, so they need naming.
+LICENCE_NAME_STEMS = (
+    'mit', 'bsd', 'isc', 'apache', 'apache-2.0', 'gpl', 'lgpl', 'agpl',
+    'gplv2', 'gplv3', 'mpl', 'epl', 'cddl', 'ofl', 'cc0', 'cc-by',
+    'zlib', 'artistic', 'boost', 'wtfpl', 'zpl', 'psf', 'openssl',
+)
+
 
 def _reads_as_a_document(source_file):
     """A file whose subject is prose, not licence text."""
@@ -133,6 +142,8 @@ def _reads_as_a_document(source_file):
     suffix = PurePath(name).suffix.lower()
 
     if any(word in stem for word in LICENCE_WORDS):
+        return False
+    if stem in LICENCE_NAME_STEMS:
         return False
     if suffix in DOCUMENT_SUFFIXES:
         return True

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -51,25 +51,26 @@ WEAK_DECLARED_MATCH_TYPES = ('documentation',)
 # the evidence record from a real SPDX-License-Identifier line. An MIT package
 # whose README credits a bundled dependency was reported as Apache-2.0.
 #
-# So inside a document, a licence named inside a sentence proves nothing.
-# What still counts is evidence that the document carries the licence, or
-# states it in a line whose whole purpose is to state it. osslili separates
-# those: a real "SPDX-License-Identifier: MIT" or "License: MIT" line comes
-# back as header_tag, while "...is licensed under the Apache License" comes
-# back as spdx_identifier.
+# So inside a document a licence has to be present, not merely named. Naming
+# is what osslili cannot tell apart from declaring: its SPDX patterns match
+# prose, and its header rule matches "License: X" anywhere in the first thirty
+# lines, mid-sentence included. "It bundles terser, license: BSD-2-Clause, for
+# minification" is reported exactly as a real SPDX-License-Identifier line is.
+# Carrying the text is different, and osslili says so with a match type of its
+# own: a README holding a full MIT licence comes back as text_similarity near
+# 0.98, so the common "licence only in the README" package still resolves.
 #
-# The cost is deliberate. A document holding a full licence text and nothing
-# else is reported as match_type documentation at a score that depends on the
-# machine, the same shape a partial mention produces, so it is refused with
-# the mentions. A package whose only licence statement is prose in its README
-# and which ships no licence file is not read from that prose.
-DOCUMENT_SUFFIXES = ('.md', '.rst', '.adoc', '.txt')
+# The suffixes are the set osslili itself scans as text. Listing fewer left
+# README.markdown and README.asciidoc outside the rule, where the credit
+# sentence this exists to refuse went straight through.
+DOCUMENT_SUFFIXES = (
+    '.md', '.markdown', '.rst', '.adoc', '.asciidoc', '.txt', '.text',
+)
 CARRIES_LICENCE_TEXT = (
     'license_file',
     'license_header',
     'text_similarity',
     'exact_hash',
-    'header_tag',
 )
 
 # LICENSE.txt and LICENCE.md are licence files that happen to have a document
@@ -106,8 +107,14 @@ def is_reportable(lic, spdx_id=None, source_file=None):
     if lic.get('category') in REJECTED_CATEGORIES:
         return False
 
-    if _reads_as_a_document(source_file or lic.get('file')):
-        return lic.get('match_type') in CARRIES_LICENCE_TEXT
+    if _reads_as_a_document(
+            source_file or lic.get('file') or lic.get('source_file')):
+        # The score matters here too. A partial text match lands in a band
+        # osslili only reports when an optional backend is installed, so
+        # accepting it at any score would put back the machine dependence this
+        # rule exists to remove.
+        return (lic.get('match_type') in CARRIES_LICENCE_TEXT
+                and lic.get('confidence', 0) >= HIGH_CONFIDENCE)
 
     if lic.get('detection_method', '') in EXACT_DETECTION_METHODS:
         return True

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -3,6 +3,7 @@ License detection using osslili CLI subprocess.
 """
 
 import logging
+import shutil
 import subprocess
 import json
 import tempfile
@@ -12,17 +13,36 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# osslili scores a match and also says what kind of evidence it is. A score
-# alone is not the whole claim: the same MIT text scores 0.95 on one machine
-# and 0.6 on another, because the similarity backend differs. Gating only on
-# the number made the reported licence depend on where upmex ran.
-#
-# category == "declared" is osslili concluding the file declares this licence,
-# which is a statement about the evidence rather than about how close the text
-# matched. Take it, take an exact identifier match, and take a high score.
-# Everything weaker than that stays out.
+# osslili scores a match and also says what kind of evidence it is: a category
+# (declared, detected, referenced, third-party) and a match_type saying which
+# rule produced it. The score alone is not the whole claim, and it is not even
+# stable: the same text scores differently depending on the similarity backend
+# available, so gating on the number alone made the reported licence depend on
+# which machine ran upmex.
 EXACT_DETECTION_METHODS = ('tag', 'spdx_identifier')
 HIGH_CONFIDENCE = 0.95
+
+# A licence a file merely mentions, and a licence belonging to bundled
+# third-party code, are not this package's licence. Neither becomes one by
+# scoring well, so these are refused before any score is considered.
+REJECTED_CATEGORIES = ('referenced', 'third-party')
+
+# "declared" is osslili concluding a file states this licence: it is a LICENSE
+# file, it is package metadata, it carries an SPDX tag or a full licence
+# header, its text matches a licence closely, or metadata pointed at a file
+# that does. Each is evidence about what the file is, independent of the score.
+#
+# One case is not. osslili also labels "declared" any pattern match inside a
+# file whose name ends .md, .rst, .txt or .adoc, with match_type
+# "documentation". A README saying "this project is licensed under MIT" earns
+# that label, so on its own it is a mention, not a declaration.
+#
+# Listed as the exception rather than as an allowlist of the good ones on
+# purpose. osslili has ten declared match types today and adds them over
+# releases; an allowlist that fell behind would silently drop real licences,
+# which is how a pyproject.toml declaring `license = {file = "LICENSE"}` came
+# to be dropped: osslili reports it as package_metadata_file at 0.6.
+WEAK_DECLARED_MATCH_TYPES = ('documentation',)
 
 # Often confused with Apache-2.0, and never right when it appears.
 KNOWN_FALSE_POSITIVES = ('Pixar',)
@@ -30,14 +50,22 @@ KNOWN_FALSE_POSITIVES = ('Pixar',)
 
 def is_reportable(lic, spdx_id=None):
     """Whether one piece of osslili evidence is strong enough to report."""
-    spdx_id = spdx_id or lic.get('spdx_id') or lic.get('detected_license')
+    if spdx_id is None:
+        spdx_id = lic.get('detected_license') or lic.get('spdx_id')
     if spdx_id in KNOWN_FALSE_POSITIVES:
         return False
-    return (
-        lic.get('confidence', 0) >= HIGH_CONFIDENCE
-        or lic.get('detection_method', '') in EXACT_DETECTION_METHODS
-        or lic.get('category') == 'declared'
-    )
+
+    if lic.get('category') in REJECTED_CATEGORIES:
+        return False
+
+    if lic.get('detection_method', '') in EXACT_DETECTION_METHODS:
+        return True
+
+    if (lic.get('category') == 'declared'
+            and lic.get('match_type') not in WEAK_DECLARED_MATCH_TYPES):
+        return True
+
+    return lic.get('confidence', 0) >= HIGH_CONFIDENCE
 
 
 
@@ -61,14 +89,18 @@ class OssliliSubprocessDetector:
             return licenses
             
         try:
-            # Write content to temporary file for osslili to process
-            # Use .txt suffix if file has no extension (e.g., LICENSE files)
-            suffix = Path(file_path).suffix or '.txt'
-            with tempfile.NamedTemporaryFile(mode='w', suffix=suffix, delete=False) as tmp:
-                tmp.write(content)
-                tmp_path = tmp.name
-            
+            # osslili decides what kind of evidence a match is partly from the
+            # file's name: LICENSE is a licence file, README.md is a document
+            # that mentions one. Writing the content to a random tmpXXXX.txt
+            # threw that away, so a package's own LICENSE was read as a passing
+            # mention and scored accordingly. Keep the caller's name, inside a
+            # directory of our own so nothing collides.
+            tmp_dir = tempfile.mkdtemp()
             try:
+                tmp_path = os.path.join(tmp_dir, Path(file_path).name)
+                with open(tmp_path, 'w') as tmp:
+                    tmp.write(content)
+
                 # Run osslili CLI without similarity threshold for better tag detection
                 result = subprocess.run(
                     ['osslili', '-f', 'evidence', tmp_path],
@@ -155,8 +187,7 @@ class OssliliSubprocessDetector:
                                         licenses.append(license_info)
                         
             finally:
-                # Clean up temp file
-                os.unlink(tmp_path)
+                shutil.rmtree(tmp_dir, ignore_errors=True)
                 
         except Exception as e:
             logger.debug(f"Osslili subprocess detection failed for {file_path}: {e}")

--- a/tests/unit/test_a_document_is_not_a_declaration.py
+++ b/tests/unit/test_a_document_is_not_a_declaration.py
@@ -16,8 +16,14 @@ import pytest
 
 from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector
 
+from upmex.licenses.osslili_subprocess import osslili_command
+
+# Skip on what the detector actually runs, not on what PATH happens to offer.
+# These tests are sensitive to the osslili version, and checking a different
+# binary than the one under test is how the version confusion started.
 pytestmark = pytest.mark.skipif(
-    shutil.which("osslili") is None, reason="the osslili CLI is not installed"
+    shutil.which(osslili_command()) is None,
+    reason="the osslili CLI upmex depends on is not installed",
 )
 
 MIT_TEXT = """MIT License
@@ -246,3 +252,26 @@ class TestWhatThisRuleGivesUp:
             shutil.rmtree(directory, ignore_errors=True)
 
         assert sorted({lic["spdx_id"] for lic in found["licenses"]}) == ["MIT"]
+
+
+class TestALicenceFileNamedAfterItsLicence:
+    """A dual-licensed project ships MIT.txt beside APACHE.txt. Neither name
+    contains a licence word and both carry a document suffix, so the rule read
+    them as prose and a directory scan came back with no licence at all."""
+
+    @pytest.mark.parametrize("name", ["MIT.txt", "APACHE.txt", "BSD.txt",
+                                      "OFL.txt", "GPL.md"])
+    def test_a_directory_scan_reads_it(self, name):
+        directory = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(directory, name), "w") as handle:
+                handle.write(FULL_MIT_TEXT)
+            found = OssliliSubprocessDetector().detect_from_directory(directory)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+        assert [lic["spdx_id"] for lic in found["licenses"]] == ["MIT"], name
+
+    @pytest.mark.parametrize("name", ["MIT.txt", "APACHE.txt", "GPL.md"])
+    def test_and_so_does_a_file_scan(self, name):
+        assert _found(name, FULL_MIT_TEXT) == ["MIT"], name

--- a/tests/unit/test_a_document_is_not_a_declaration.py
+++ b/tests/unit/test_a_document_is_not_a_declaration.py
@@ -1,0 +1,134 @@
+"""A README talks about licences. That is not the same as having one.
+
+These drive the real osslili binary rather than a mock, because the defect
+they cover was invisible to mocks: the evidence hand-written into a test was
+not the evidence osslili actually emits. osslili's SPDX patterns match prose,
+so "the bundled minifier is licensed under the Apache License" arrives as
+detection_method 'tag' at confidence 1.0, and an MIT package was reported as
+Apache-2.0 on the strength of a sentence crediting a dependency.
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("osslili") is None, reason="the osslili CLI is not installed"
+)
+
+MIT_TEXT = """MIT License
+
+Copyright (c) 2024 Example
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software."""
+
+CREDITS_A_DEPENDENCY = (
+    "Widget parser.\n\n"
+    "The bundled minifier is licensed under the Apache License, Version 2.0.\n"
+    "See http://www.apache.org/licenses/LICENSE-2.0.\n"
+)
+
+
+def _found(name, content):
+    return [lic["spdx_id"] for lic in
+            OssliliSubprocessDetector().detect_from_file(name, content)]
+
+
+class TestAMentionIsNotADeclaration:
+    def test_a_readme_crediting_a_dependency_reports_nothing(self):
+        assert _found("README.md", CREDITS_A_DEPENDENCY) == []
+
+    @pytest.mark.parametrize("name", ["README.md", "CHANGELOG.md", "docs.rst",
+                                      "guide.adoc", "notes.txt"])
+    def test_in_every_kind_of_document(self, name):
+        assert _found(name, CREDITS_A_DEPENDENCY) == []
+
+    def test_the_package_is_not_relabelled_by_its_own_readme(self):
+        """The whole point: an MIT package must not come back Apache-2.0."""
+        found = _found("README.md", CREDITS_A_DEPENDENCY)
+        assert "Apache-2.0" not in found
+
+
+class TestADocumentCanStillDeclare:
+    """A line whose whole purpose is to state the licence is a declaration,
+    wherever it sits."""
+
+    def test_an_spdx_identifier_line(self):
+        assert _found("README.md", "SPDX-License-Identifier: MIT\n\nA parser.\n") == ["MIT"]
+
+    def test_a_license_line(self):
+        assert _found("README.md", "License: MIT\n\nA parser.\n") == ["MIT"]
+
+
+class TestALicenceFileIsNeverADocument:
+    """LICENSE.txt and LICENCE.md carry a document suffix and are not
+    documents. Dropping them would be the worse failure by far."""
+
+    @pytest.mark.parametrize("name", [
+        "LICENSE", "LICENSE.txt", "LICENSE.md", "LICENCE", "LICENCE.txt",
+        "COPYING", "COPYING.txt", "NOTICE", "UNLICENSE", "licenses.txt",
+    ])
+    def test_it_is_read(self, name):
+        assert _found(name, MIT_TEXT) == ["MIT"], name
+
+
+class TestADirectoryScan:
+    def test_the_readme_does_not_add_a_licence_the_package_lacks(self):
+        directory = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(directory, "README.md"), "w") as handle:
+                handle.write(CREDITS_A_DEPENDENCY)
+            with open(os.path.join(directory, "LICENSE"), "w") as handle:
+                handle.write(MIT_TEXT)
+
+            found = OssliliSubprocessDetector().detect_from_directory(directory)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+        assert sorted({lic["spdx_id"] for lic in found["licenses"]}) == ["MIT"]
+
+
+class TestTheContentIsWhatGetsScanned:
+    """Every other test here mocks subprocess.run and so never checks that the
+    content reaches the file osslili reads. An implementation that wrote
+    nothing would pass those and find nothing in production."""
+
+    def test_the_licence_is_read_from_the_content_not_the_name(self):
+        assert _found("LICENSE", MIT_TEXT) == ["MIT"]
+
+    def test_an_empty_licence_file_yields_nothing(self):
+        assert _found("LICENSE", "") == []
+
+    def test_the_name_alone_is_not_enough(self):
+        assert _found("LICENSE", "This file intentionally left blank.\n") == []
+
+
+class TestADegenerateFilename:
+    """The content is written to a file named after the caller's path. Some
+    paths have no usable basename, and writing to those raises an error the
+    broad except turns into a silent empty result, so the licence disappears
+    with no sign of why."""
+
+    @pytest.mark.parametrize("name", ["", ".", "..", "/", "./", "../", "..."])
+    def test_the_licence_is_still_found(self, name):
+        assert _found(name, MIT_TEXT) == ["MIT"], name
+
+    def test_a_path_with_directories_uses_only_the_last_part(self):
+        assert _found("pkg/nested/LICENSE", MIT_TEXT) == ["MIT"]
+
+    def test_an_absolute_path_too(self):
+        assert _found("/opt/pkg/LICENSE", MIT_TEXT) == ["MIT"]
+
+    def test_a_document_deep_in_a_tree_is_still_a_document(self):
+        assert _found("docs/guide/README.md", CREDITS_A_DEPENDENCY) == []

--- a/tests/unit/test_a_document_is_not_a_declaration.py
+++ b/tests/unit/test_a_document_is_not_a_declaration.py
@@ -49,8 +49,10 @@ class TestAMentionIsNotADeclaration:
     def test_a_readme_crediting_a_dependency_reports_nothing(self):
         assert _found("README.md", CREDITS_A_DEPENDENCY) == []
 
-    @pytest.mark.parametrize("name", ["README.md", "CHANGELOG.md", "docs.rst",
-                                      "guide.adoc", "notes.txt"])
+    @pytest.mark.parametrize("name", [
+        "README.md", "README.markdown", "README.text", "README.asciidoc",
+        "CHANGELOG.md", "docs.rst", "guide.adoc", "notes.txt",
+    ])
     def test_in_every_kind_of_document(self, name):
         assert _found(name, CREDITS_A_DEPENDENCY) == []
 
@@ -60,15 +62,65 @@ class TestAMentionIsNotADeclaration:
         assert "Apache-2.0" not in found
 
 
-class TestADocumentCanStillDeclare:
-    """A line whose whole purpose is to state the licence is a declaration,
-    wherever it sits."""
+# The complete text, because a document only counts when it carries the
+# licence, and osslili measures that by how closely the text matches.
+FULL_MIT_TEXT = """MIT License
 
-    def test_an_spdx_identifier_line(self):
-        assert _found("README.md", "SPDX-License-Identifier: MIT\n\nA parser.\n") == ["MIT"]
+Copyright (c) 2024 Example
 
-    def test_a_license_line(self):
-        assert _found("README.md", "License: MIT\n\nA parser.\n") == ["MIT"]
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE."""
+
+
+class TestADocumentThatCarriesTheLicence:
+    """Naming a licence is what osslili cannot tell from declaring one, so
+    the licence has to be present. Carrying the text is a different match
+    type, and that is what counts here."""
+
+    def test_a_readme_holding_the_licence_text_is_read(self):
+        assert _found("README.md", "# mypkg\n\n## License\n\n" + FULL_MIT_TEXT) == ["MIT"]
+
+    def test_in_a_markdown_variant_too(self):
+        assert _found("README.markdown", "# mypkg\n\n## License\n\n" + FULL_MIT_TEXT) == ["MIT"]
+
+    def test_a_bare_spdx_line_is_not_enough_on_its_own(self):
+        """The cost of the rule, stated. osslili reports a real
+        SPDX-License-Identifier line and the sentence "it bundles terser,
+        license: BSD-2-Clause" as the same kind of evidence, so neither can
+        be trusted inside a document. Package metadata carries this case."""
+        assert _found("README.md", "SPDX-License-Identifier: MIT\n\nA parser.\n") == []
+
+    def test_nor_is_a_license_line(self):
+        assert _found("README.md", "License: MIT\n\nA parser.\n") == []
+
+
+class TestTheProseThatLooksLikeAHeader:
+    """osslili matches "License: X" anywhere in the first thirty lines,
+    mid-sentence included, and reports it exactly as a real header."""
+
+    @pytest.mark.parametrize("line", [
+        "It bundles terser, license: BSD-2-Clause, for minification.\n",
+        "| terser | License: BSD-2-Clause |\n",
+        "- lodash, license: MIT\n",
+        "Dependencies: react (License: MIT), terser (License: BSD-2-Clause)\n",
+    ])
+    def test_a_dependency_credit_is_not_the_package_licence(self, line):
+        assert _found("README.md", line) == []
 
 
 class TestALicenceFileIsNeverADocument:
@@ -132,3 +184,21 @@ class TestADegenerateFilename:
 
     def test_a_document_deep_in_a_tree_is_still_a_document(self):
         assert _found("docs/guide/README.md", CREDITS_A_DEPENDENCY) == []
+
+
+class TestLicenceFilesWithASuffixedName:
+    """A dual-licensed project ships LICENSE-MIT.txt and LICENSE-APACHE.txt.
+    Those are licence files with a document suffix, and reading them as
+    documents would refuse the very files that hold the licence."""
+
+    @pytest.mark.parametrize("name", [
+        "LICENSE-MIT.txt", "LICENSE-APACHE.txt", "LICENCE-MIT.md",
+        "license_apache.md", "licenses.txt", "COPYING.LESSER",
+    ])
+    def test_it_is_read(self, name):
+        assert _found(name, "SPDX-License-Identifier: MIT\n") == ["MIT"], name
+
+    @pytest.mark.parametrize("name", ["CHANGELOG.md", "CONTRIBUTING.md",
+                                      "docs/install.rst", "notes.txt"])
+    def test_but_a_document_is_still_a_document(self, name):
+        assert _found(name, "SPDX-License-Identifier: MIT\n") == [], name

--- a/tests/unit/test_a_document_is_not_a_declaration.py
+++ b/tests/unit/test_a_document_is_not_a_declaration.py
@@ -50,8 +50,12 @@ class TestAMentionIsNotADeclaration:
         assert _found("README.md", CREDITS_A_DEPENDENCY) == []
 
     @pytest.mark.parametrize("name", [
-        "README.md", "README.markdown", "README.text", "README.asciidoc",
+        "README.md", "README.markdown", "README.mdown", "README.text",
+        "README.asciidoc", "README.textile", "README.org",
         "CHANGELOG.md", "docs.rst", "guide.adoc", "notes.txt",
+        # No suffix at all, which the rule used to miss entirely. GNU-style
+        # and many C and Go projects ship exactly these.
+        "README", "INSTALL", "CHANGELOG", "NEWS", "TODO", "CONTRIBUTING",
     ])
     def test_in_every_kind_of_document(self, name):
         assert _found(name, CREDITS_A_DEPENDENCY) == []
@@ -202,3 +206,43 @@ class TestLicenceFilesWithASuffixedName:
                                       "docs/install.rst", "notes.txt"])
     def test_but_a_document_is_still_a_document(self, name):
         assert _found(name, "SPDX-License-Identifier: MIT\n") == [], name
+
+
+
+class TestWhatThisRuleGivesUp:
+    """Stated as a test so it is a decision on the record rather than a
+    surprise: a package whose only licence statement is prose in its README,
+    with no licence file and nothing in its metadata."""
+
+    def test_a_readme_carrying_the_licence_is_read_when_that_file_is_scanned(self):
+        assert _found("README.md", "# mypkg\n\n## License\n\n" + FULL_MIT_TEXT) == ["MIT"]
+
+    def test_but_not_when_the_directory_is_scanned(self):
+        """Scanning a directory, osslili measures a short window around the
+        word "license" rather than the whole file, and a bare mention scores
+        the same as a document carrying the entire licence. Nothing separates
+        them, so both are refused."""
+        directory = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(directory, "README.md"), "w") as handle:
+                handle.write("# mypkg\n\n## License\n\n" + FULL_MIT_TEXT)
+            found = OssliliSubprocessDetector().detect_from_directory(directory)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+        assert found["licenses"] == []
+
+    def test_and_a_licence_file_alongside_it_is_still_read(self):
+        """Which is why the loss is narrow: the shape needs no licence file
+        anywhere, and almost every package has one."""
+        directory = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(directory, "README.md"), "w") as handle:
+                handle.write(CREDITS_A_DEPENDENCY)
+            with open(os.path.join(directory, "LICENSE"), "w") as handle:
+                handle.write(MIT_TEXT)
+            found = OssliliSubprocessDetector().detect_from_directory(directory)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+        assert sorted({lic["spdx_id"] for lic in found["licenses"]}) == ["MIT"]

--- a/tests/unit/test_the_evidence_gate.py
+++ b/tests/unit/test_the_evidence_gate.py
@@ -164,13 +164,45 @@ class TestAMentionIsNotADeclaration:
             README_CREDITING_A_DEPENDENCY[2], source_file="README.md"
         )
 
-    def test_but_a_line_that_exists_to_state_the_licence_is(self):
-        """A real SPDX-License-Identifier or License: line. osslili reports
-        those as header_tag, which is how they are told from prose."""
-        assert is_reportable(
-            {"detected_license": "MIT", "confidence": 1.0,
+    def test_a_header_shaped_line_is_not_rescued_either(self):
+        """osslili reports a real SPDX-License-Identifier line and the
+        sentence "it bundles terser, license: BSD-2-Clause" both as
+        header_tag, so inside a document neither can be trusted."""
+        assert not is_reportable(
+            {"detected_license": "BSD-2-Clause", "confidence": 1.0,
              "detection_method": "tag", "category": "declared",
              "match_type": "header_tag"},
+            source_file="README.md",
+        )
+
+    def test_a_match_type_the_rule_has_not_heard_of_stays_out(self):
+        """The document branch names what it accepts. A blocklist would let
+        every future match type in unexamined."""
+        assert not is_reportable(
+            {"detected_license": "MIT", "confidence": 1.0,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "some_new_thing"},
+            source_file="README.md",
+        )
+
+    @pytest.mark.parametrize("match_type", [
+        "license_file", "license_header", "text_similarity", "exact_hash",
+    ])
+    def test_but_evidence_the_document_carries_it_does(self, match_type):
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.98,
+             "detection_method": "dice-sorensen", "category": "declared",
+             "match_type": match_type},
+            source_file="README.md",
+        )
+
+    def test_and_not_a_weak_text_match(self):
+        """A partial match lands in a band osslili only reports when an
+        optional backend is installed."""
+        assert not is_reportable(
+            {"detected_license": "MIT", "confidence": 0.55,
+             "detection_method": "dice-sorensen", "category": "declared",
+             "match_type": "text_similarity"},
             source_file="README.md",
         )
 
@@ -283,6 +315,29 @@ class TestTheOldOutputFormat:
         ], key="results")):
             found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
         assert found == []
+
+
+class TestTheOldFormatCarriesTheFileUnderAnotherName:
+    """The pre-evidence format names the file source_file, not file. Reading
+    only one key left the document rule silently off for that whole branch."""
+
+    def test_a_mention_in_a_document_is_still_refused(self):
+        with patch("subprocess.run", return_value=_result([
+            {"spdx_id": "Apache-2.0", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "spdx_identifier", "source_file": "README.md"}
+        ], key="results")):
+            found = OssliliSubprocessDetector().detect_from_directory("/repo")
+        assert found["licenses"] == []
+
+    def test_and_a_licence_file_is_still_read(self):
+        with patch("subprocess.run", return_value=_result([
+            {"spdx_id": "MIT", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "spdx_identifier", "source_file": "LICENSE"}
+        ], key="results")):
+            found = OssliliSubprocessDetector().detect_from_directory("/repo")
+        assert [lic["spdx_id"] for lic in found["licenses"]] == ["MIT"]
 
 
 class TestADirectoryScanUsesTheSameRule:

--- a/tests/unit/test_the_evidence_gate.py
+++ b/tests/unit/test_the_evidence_gate.py
@@ -185,14 +185,52 @@ class TestAMentionIsNotADeclaration:
             source_file="README.md",
         )
 
-    @pytest.mark.parametrize("match_type", [
-        "license_file", "license_header", "text_similarity", "exact_hash",
-    ])
-    def test_but_evidence_the_document_carries_it_does(self, match_type):
+    @pytest.mark.parametrize("match_type", ["license_file", "exact_hash"])
+    def test_but_evidence_identifying_the_file_itself_does(self, match_type):
+        """A name or a hash, so no score is involved."""
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.1,
+             "detection_method": "regex", "category": "declared",
+             "match_type": match_type},
+            source_file="README.md",
+        )
+
+    def test_and_a_measured_match_against_the_licence_text_does(self):
         assert is_reportable(
             {"detected_license": "MIT", "confidence": 0.98,
              "detection_method": "dice-sorensen", "category": "declared",
-             "match_type": match_type},
+             "match_type": "text_similarity"},
+            source_file="README.md",
+        )
+
+    def test_a_licence_header_claim_does_not(self):
+        """osslili emits license_header at 0.6 for the single sentence "the
+        bundled minifier is licensed under the Apache License", so inside a
+        document it is another spelling of a mention."""
+        assert not is_reportable(
+            {"detected_license": "Apache-2.0", "confidence": 0.6,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "license_header"},
+            source_file="README.md",
+        )
+
+    def test_but_it_does_in_a_licence_file(self):
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.6,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "license_header"},
+            source_file="LICENSE",
+        )
+
+    @pytest.mark.parametrize("confidence", [0.6, 0.95, 1.0])
+    def test_a_documentation_match_never_counts(self, confidence):
+        """Its score is not comparable between osslili's two modes. Scanning
+        one file a mention scores 0.6; scanning a directory the same mention
+        scores 0.95, the score a document carrying the whole licence gets."""
+        assert not is_reportable(
+            {"detected_license": "MIT", "confidence": confidence,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "documentation"},
             source_file="README.md",
         )
 
@@ -211,6 +249,28 @@ class TestAMentionIsNotADeclaration:
         assert is_reportable(
             README_CREDITING_A_DEPENDENCY[0], source_file="package.json"
         )
+
+
+class TestTheDocumentTextFloor:
+    """A measured match against the licence text is the one thing a mention
+    cannot fake, but only near the top of the scale. Pinned in both directions
+    so the threshold cannot drift either way unnoticed."""
+
+    def _text_match(self, confidence):
+        return {"detected_license": "MIT", "confidence": confidence,
+                "detection_method": "dice-sorensen", "category": "declared",
+                "match_type": "text_similarity"}
+
+    @pytest.mark.parametrize("confidence", [0.95, 0.96, 0.97, 0.99, 1.0])
+    def test_at_or_above_the_threshold_it_counts(self, confidence):
+        assert is_reportable(self._text_match(confidence), source_file="README.md")
+
+    @pytest.mark.parametrize("confidence", [0.5, 0.9, 0.91, 0.94, 0.949])
+    def test_below_it_does_not(self, confidence):
+        """The band under the threshold is reported only when an optional
+        similarity backend is installed, which is the machine dependence this
+        whole rule exists to remove."""
+        assert not is_reportable(self._text_match(confidence), source_file="README.md")
 
 
 class TestTheScoreBoundary:
@@ -445,3 +505,40 @@ class TestTheRuleKeepsUpWithOsslili:
                  "detection_method": "regex", "category": "declared",
                  "match_type": match_type}
             ), f"{match_type} is dropped"
+
+
+class TestAWindowsSeparator:
+    """Archive members and nuspec declarations carry backslashes, and upmex
+    runs on POSIX, where a backslash is an ordinary character. Left alone the
+    whole path became the filename, so the rule read the directory as part of
+    the name."""
+
+    @pytest.mark.parametrize("name,document", [
+        ("docs\\README", True),
+        ("docs\\README.md", True),
+        ("a\\b\\INSTALL", True),
+        ("docs\\LICENSE", False),
+        ("pkg\\LICENSE.md", False),
+        ("docs/README", True),
+        ("docs/LICENSE", False),
+    ])
+    def test_the_name_is_the_last_part_either_way(self, name, document):
+        from upmex.licenses.osslili_subprocess import _reads_as_a_document
+
+        assert _reads_as_a_document(name) is document, name
+
+    def test_a_mention_behind_a_backslash_is_still_refused(self):
+        assert not is_reportable(
+            {"detected_license": "Apache-2.0", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "spdx_identifier"},
+            source_file="docs\\README",
+        )
+
+    def test_and_a_licence_file_behind_one_is_still_read(self):
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.6,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "license_file"},
+            source_file="pkg\\LICENSE.md",
+        )

--- a/tests/unit/test_the_evidence_gate.py
+++ b/tests/unit/test_the_evidence_gate.py
@@ -1,117 +1,335 @@
 """What upmex keeps out of osslili's evidence, and why.
 
-osslili scores a match and also says what kind of evidence it is. Gating on
-the score alone made the answer depend on the machine: the same MIT text was
-scored 0.95 by one similarity backend and 0.6 by another, so a package came
-back MIT locally and unlicensed in CI. These pin the rule to the evidence
-rather than to the number.
+osslili reports a score, a category (declared, detected, referenced,
+third-party) and a match_type saying which rule fired. Gating on the score
+alone made the answer depend on the machine: the same MIT text was scored 0.95
+by one similarity backend and 0.6 by another, so a package came back MIT
+locally and unlicensed in CI.
+
+Gating on the category alone is not right either. osslili labels "declared"
+any pattern match in a file ending .md, .rst, .txt or .adoc, so a README that
+says "licensed under MIT" would count as a declaration. The match_type is what
+separates the two.
 """
 
 import json
+import os
 from unittest.mock import patch
+
+import pytest
 
 from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector, is_reportable
 
 MIT_TEXT = "MIT License\n\nPermission is hereby granted, free of charge"
 
 
-def _result(evidence):
+def _result(evidence, key="scan_results"):
+    payload = (
+        {"scan_results": [{"license_evidence": evidence, "copyright_evidence": []}]}
+        if key == "scan_results"
+        else {"results": [{"licenses": evidence}]}
+    )
+
     class Result:
         returncode = 0
         stderr = ""
-        stdout = json.dumps(
-            {"scan_results": [{"license_evidence": evidence, "copyright_evidence": []}]}
-        )
+        stdout = json.dumps(payload)
 
     return Result()
 
 
-# The two scorings of the same file, taken from a real run on each machine.
-LOCAL_SCORING = [
+def _spdx(found):
+    return [lic["spdx_id"] for lic in found]
+
+
+class TestOssliliSeesTheRealFilename:
+    """The root of the CI failure. osslili decides what kind of evidence a
+    match is partly from the file's name, and the content was being written to
+    a random tmpXXXX.txt, so a package's own LICENSE was read as a passing
+    mention in a text file."""
+
+    def test_the_callers_name_reaches_osslili(self):
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["path"] = cmd[-1]
+            return _result([])
+
+        with patch("subprocess.run", side_effect=fake_run):
+            OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+
+        assert os.path.basename(seen["path"]) == "LICENSE"
+
+    def test_an_extension_is_kept_too(self):
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["path"] = cmd[-1]
+            return _result([])
+
+        with patch("subprocess.run", side_effect=fake_run):
+            OssliliSubprocessDetector().detect_from_file("LICENSE.md", MIT_TEXT)
+
+        assert os.path.basename(seen["path"]) == "LICENSE.md"
+
+    def test_nothing_is_left_behind(self):
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["path"] = cmd[-1]
+            return _result([])
+
+        with patch("subprocess.run", side_effect=fake_run):
+            OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+
+        assert not os.path.exists(seen["path"])
+        assert not os.path.exists(os.path.dirname(seen["path"]))
+
+
+# What osslili really returns for a file named LICENSE holding MIT text. The
+# score differs by machine; the match_type does not.
+LICENCE_FILE_HIGH = [
+    {"detected_license": "MIT", "confidence": 1.0, "detection_method": "regex",
+     "category": "declared", "match_type": "license_file"},
     {"detected_license": "MIT", "confidence": 0.9, "detection_method": "keyword",
      "category": "detected", "match_type": "keyword"},
-    {"detected_license": "MIT", "confidence": 0.95, "detection_method": "regex",
-     "category": "declared", "match_type": "documentation"},
 ]
-CI_SCORING = [
+LICENCE_FILE_LOW = [
+    {"detected_license": "MIT", "confidence": 0.6, "detection_method": "regex",
+     "category": "declared", "match_type": "license_file"},
     {"detected_license": "MIT", "confidence": 0.9, "detection_method": "keyword",
      "category": "detected", "match_type": "keyword"},
-    {"detected_license": "MIT", "confidence": 0.6, "detection_method": "regex",
-     "category": "declared", "match_type": "documentation"},
 ]
 
 
 class TestTheSameFileGivesTheSameAnswer:
     def test_the_high_scoring_machine_reports_mit(self):
-        with patch("subprocess.run", return_value=_result(LOCAL_SCORING)):
+        with patch("subprocess.run", return_value=_result(LICENCE_FILE_HIGH)):
             found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
-        assert "MIT" in [lic["spdx_id"] for lic in found]
+        assert _spdx(found) == ["MIT"]
 
     def test_the_low_scoring_machine_reports_mit_too(self):
-        """This is the one that failed. 0.6 on a declared licence is still MIT."""
-        with patch("subprocess.run", return_value=_result(CI_SCORING)):
+        """This is the one that failed in CI. The score moved, the evidence
+        did not, so the answer must not move either."""
+        with patch("subprocess.run", return_value=_result(LICENCE_FILE_LOW)):
             found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
-        assert "MIT" in [lic["spdx_id"] for lic in found]
+        assert _spdx(found) == ["MIT"]
+
+    def test_it_is_the_match_type_doing_the_work(self):
+        """Same score, same category, only the match_type differs. If this
+        passed on the score the two would agree, and they must not."""
+        low_declaring = dict(LICENCE_FILE_LOW[0])
+        low_mention = dict(low_declaring, match_type="documentation")
+
+        assert is_reportable(low_declaring)
+        assert not is_reportable(low_mention)
 
 
-class TestWhatStaysOut:
-    def test_a_weak_detection_is_not_reported(self):
-        """Nothing declared it, nothing matched exactly, the score is low."""
-        assert not is_reportable(
-            {"detected_license": "GPL-3.0", "confidence": 0.6,
-             "detection_method": "keyword", "category": "detected"}
-        )
+class TestAMentionIsNotADeclaration:
+    """osslili labels a pattern match in any .md/.rst/.txt/.adoc file
+    "declared" with match_type "documentation"."""
 
-    def test_a_referenced_licence_is_not_a_declared_one(self):
-        """A file that mentions a licence has not declared it."""
-        assert not is_reportable(
-            {"detected_license": "MIT", "confidence": 0.7,
-             "detection_method": "regex", "category": "referenced"}
-        )
-
-    def test_a_third_party_licence_is_not_a_declared_one(self):
+    def test_a_readme_mentioning_mit_is_not_reported(self):
         assert not is_reportable(
             {"detected_license": "MIT", "confidence": 0.7,
-             "detection_method": "regex", "category": "third-party"}
+             "detection_method": "regex", "category": "declared",
+             "match_type": "documentation"}
         )
 
-    def test_the_known_false_positive_stays_out_however_it_is_categorised(self):
-        """Pixar is the standard Apache-2.0 confusion, and never right."""
-        assert not is_reportable(
-            {"detected_license": "Pixar", "confidence": 1.0,
-             "detection_method": "tag", "category": "declared"}
-        )
-
-    def test_it_stays_out_of_a_real_scan_too(self):
+    def test_not_through_a_real_scan_either(self):
         with patch("subprocess.run", return_value=_result([
-            {"detected_license": "Pixar", "confidence": 1.0,
-             "detection_method": "tag", "category": "declared"}
+            {"detected_license": "MIT", "confidence": 0.7,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "documentation"}
+        ])):
+            found = OssliliSubprocessDetector().detect_from_file("README.md", MIT_TEXT)
+        assert found == []
+
+    def test_but_a_high_score_still_carries_it(self):
+        """A near-exact text match is a licence however the file is named."""
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.99,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "documentation"}
+        )
+
+
+class TestSomeoneElsesLicenceStaysOut:
+    """A referenced licence and a bundled third-party licence are not this
+    package's licence, and no score makes them one."""
+
+    @pytest.mark.parametrize("category", ["referenced", "third-party"])
+    @pytest.mark.parametrize("confidence", [0.5, 0.95, 1.0])
+    def test_at_any_score(self, category, confidence):
+        assert not is_reportable(
+            {"detected_license": "GPL-3.0", "confidence": confidence,
+             "detection_method": "regex", "category": category,
+             "match_type": "license_file"}
+        )
+
+    def test_even_with_an_exact_tag(self):
+        assert not is_reportable(
+            {"detected_license": "GPL-3.0", "confidence": 1.0,
+             "detection_method": "tag", "category": "third-party",
+             "match_type": "spdx_identifier"}
+        )
+
+    def test_through_a_real_scan(self):
+        with patch("subprocess.run", return_value=_result([
+            {"detected_license": "GPL-3.0", "confidence": 1.0,
+             "detection_method": "regex", "category": "third-party",
+             "match_type": "license_file"}
         ])):
             found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
         assert found == []
+
+
+class TestTheKnownFalsePositive:
+    def test_pixar_stays_out_however_it_is_evidenced(self):
+        assert not is_reportable(
+            {"detected_license": "Pixar", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "spdx_identifier"}
+        )
+
+    def test_through_a_real_scan(self):
+        with patch("subprocess.run", return_value=_result([
+            {"detected_license": "Pixar", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "spdx_identifier"}
+        ])):
+            found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+        assert found == []
+
+    def test_the_old_output_format_filters_it_too(self):
+        with patch("subprocess.run", return_value=_result([
+            {"spdx_id": "Pixar", "confidence": 1.0, "detection_method": "tag"}
+        ], key="results")):
+            found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+        assert found == []
+
+
+class TestTheOldOutputFormat:
+    """osslili's pre-evidence format carries no category, so only the score
+    and the detection method can speak for it."""
+
+    def test_an_exact_tag_gets_in(self):
+        with patch("subprocess.run", return_value=_result([
+            {"spdx_id": "MIT", "confidence": 0.2, "detection_method": "tag"}
+        ], key="results")):
+            found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+        assert _spdx(found) == ["MIT"]
+
+    def test_a_low_scoring_guess_does_not(self):
+        with patch("subprocess.run", return_value=_result([
+            {"spdx_id": "MIT", "confidence": 0.6, "detection_method": "keyword"}
+        ], key="results")):
+            found = OssliliSubprocessDetector().detect_from_file("LICENSE", MIT_TEXT)
+        assert found == []
+
+
+class TestADirectoryScanUsesTheSameRule:
+    def _scan(self, evidence):
+        with patch("subprocess.run", return_value=_result(evidence)):
+            return OssliliSubprocessDetector().detect_from_directory("/repo")
+
+    def test_a_declared_licence_is_reported(self):
+        found = self._scan(LICENCE_FILE_LOW)
+        assert [lic["spdx_id"] for lic in found["licenses"]] == ["MIT"]
+
+    def test_a_third_party_licence_is_not(self):
+        found = self._scan([
+            {"detected_license": "GPL-3.0", "confidence": 1.0,
+             "detection_method": "regex", "category": "third-party",
+             "match_type": "license_file"}
+        ])
+        assert found["licenses"] == []
+
+    def test_a_documentation_mention_is_not(self):
+        found = self._scan([
+            {"detected_license": "MIT", "confidence": 0.7,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "documentation"}
+        ])
+        assert found["licenses"] == []
 
 
 class TestWhatStillGetsIn:
     def test_a_high_score_is_enough_on_its_own(self):
         assert is_reportable(
             {"detected_license": "MIT", "confidence": 0.97,
-             "detection_method": "keyword", "category": "detected"}
+             "detection_method": "keyword", "category": "detected",
+             "match_type": "keyword"}
         )
 
-    def test_an_exact_identifier_is_enough_at_any_score(self):
+    @pytest.mark.parametrize("method", ["tag", "spdx_identifier"])
+    def test_an_exact_identifier_is_enough_at_any_score(self, method):
         assert is_reportable(
             {"detected_license": "MIT", "confidence": 0.1,
-             "detection_method": "spdx_identifier", "category": "detected"}
+             "detection_method": method, "category": "detected",
+             "match_type": "keyword"}
         )
 
-    def test_a_tag_is_enough_at_any_score(self):
+    @pytest.mark.parametrize("match_type", [
+        "license_file", "package_metadata", "spdx_identifier",
+        "license_header", "text_similarity", "header_tag",
+        "package_metadata_classifier", "package_metadata_file", "exact_hash",
+    ])
+    def test_every_way_osslili_says_a_file_declares_a_licence(self, match_type):
         assert is_reportable(
             {"detected_license": "MIT", "confidence": 0.1,
-             "detection_method": "tag", "category": "detected"}
+             "detection_method": "regex", "category": "declared",
+             "match_type": match_type}
         )
 
-    def test_declared_is_enough_at_any_score(self):
-        assert is_reportable(
-            {"detected_license": "MIT", "confidence": 0.1,
-             "detection_method": "regex", "category": "declared"}
+    def test_a_pyproject_pointing_at_a_licence_file(self):
+        """PEP 639. osslili reads the file pyproject.toml names, reports it
+        against pyproject.toml as package_metadata_file, and caps it at 0.6.
+        An allowlist that had not heard of that match type dropped it."""
+        with patch("subprocess.run", return_value=_result([
+            {"detected_license": "MIT", "confidence": 0.6,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "package_metadata_file"}
+        ])):
+            found = OssliliSubprocessDetector().detect_from_file(
+                "pyproject.toml", MIT_TEXT
+            )
+        assert _spdx(found) == ["MIT"]
+
+
+class TestTheRuleKeepsUpWithOsslili:
+    """The rule names the one match type it refuses. If osslili grows another
+    weak one, this is what says so, rather than a licence quietly going
+    missing months later."""
+
+    def _declared_match_types_in_osslili(self):
+        import pathlib
+        import re
+
+        import osslili
+
+        source = pathlib.Path(osslili.__file__).parent
+        found = set()
+        for path in source.rglob("*.py"):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            found.update(re.findall(r'DECLARED\.value,\s*"([a-z_]+)"', text))
+            found.update(re.findall(r'match_type\s*=\s*"([a-z_]+)"', text))
+        return found
+
+    def test_osslili_still_emits_the_one_we_refuse(self):
+        types = self._declared_match_types_in_osslili()
+        assert types, "could not read osslili's match types"
+        assert "documentation" in types, (
+            "osslili no longer emits the match type this rule refuses; "
+            "the exception may be stale"
         )
+
+    def test_every_other_declared_type_is_accepted(self):
+        for match_type in self._declared_match_types_in_osslili():
+            if match_type == "documentation":
+                continue
+            assert is_reportable(
+                {"detected_license": "MIT", "confidence": 0.1,
+                 "detection_method": "regex", "category": "declared",
+                 "match_type": match_type}
+            ), f"{match_type} is dropped"

--- a/tests/unit/test_the_evidence_gate.py
+++ b/tests/unit/test_the_evidence_gate.py
@@ -542,3 +542,79 @@ class TestAWindowsSeparator:
              "match_type": "license_file"},
             source_file="pkg\\LICENSE.md",
         )
+
+
+class TestTheOrderTheChecksRunIn:
+    """is_reportable answers in a fixed order, and each step only means what
+    it means because of what ran before it. Nothing pinned that, so the steps
+    could be reordered into a wrong answer with the suite still green."""
+
+    def test_a_third_party_licence_loses_even_where_a_document_would_win(self):
+        """Refusing borrowed licences has to come first. A vendored copy of a
+        licence text is a licence file, and identifying it as one is exactly
+        what the document branch accepts without a score."""
+        assert not is_reportable(
+            {"detected_license": "Apache-2.0", "confidence": 1.0,
+             "detection_method": "regex", "category": "third-party",
+             "match_type": "license_file"},
+            source_file="vendor/terser/README.md",
+        )
+
+    def test_and_a_referenced_one_too(self):
+        assert not is_reportable(
+            {"detected_license": "Apache-2.0", "confidence": 1.0,
+             "detection_method": "regex", "category": "referenced",
+             "match_type": "exact_hash"},
+            source_file="README.md",
+        )
+
+    def test_the_known_false_positive_loses_before_anything_else(self):
+        assert not is_reportable(
+            {"detected_license": "Pixar", "confidence": 1.0,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "exact_hash"},
+            source_file="README.md",
+        )
+        assert not is_reportable(
+            {"detected_license": "Pixar", "confidence": 1.0,
+             "detection_method": "regex", "category": "declared",
+             "match_type": "license_file"},
+            source_file="LICENSE",
+        )
+
+    def test_the_evidence_format_key_names_the_licence(self):
+        """Records in the current format carry detected_license. The older
+        format carries spdx_id. Reading them in the wrong order judges one
+        licence and reports another."""
+        assert not is_reportable(
+            {"detected_license": "Pixar", "spdx_id": "MIT", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "spdx_identifier"}
+        )
+
+    def test_and_the_older_key_is_still_read_when_it_is_all_there_is(self):
+        assert not is_reportable(
+            {"spdx_id": "Pixar", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared"}
+        )
+
+
+class TestALicenceFileNamedAfterItsLicence:
+    """A dual-licensed project ships MIT.txt beside APACHE.txt. Neither name
+    contains a licence word, and both have a document suffix."""
+
+    @pytest.mark.parametrize("name", [
+        "MIT.txt", "BSD.txt", "APACHE.txt", "OFL.txt", "GPL.md",
+        "mit.txt", "cc0.txt", "zlib.txt",
+    ])
+    def test_it_is_not_a_document(self, name):
+        from upmex.licenses.osslili_subprocess import _reads_as_a_document
+
+        assert not _reads_as_a_document(name), name
+
+    @pytest.mark.parametrize("name", ["mitigations.md", "notes.txt",
+                                      "README.md", "INSTALL"])
+    def test_but_a_document_that_merely_looks_similar_is_still_one(self, name):
+        from upmex.licenses.osslili_subprocess import _reads_as_a_document
+
+        assert _reads_as_a_document(name), name

--- a/tests/unit/test_the_evidence_gate.py
+++ b/tests/unit/test_the_evidence_gate.py
@@ -125,32 +125,89 @@ class TestTheSameFileGivesTheSameAnswer:
         assert not is_reportable(low_mention)
 
 
+# What osslili really emits for a README sentence crediting a dependency,
+# taken from a run of the binary. The tag record is the one that matters: the
+# SPDX patterns match prose, so a mention is reported the same way a genuine
+# identifier is, at confidence 1.0. An earlier version of this test invented a
+# lone documentation record at 0.7, which the gate refused, so the test passed
+# while production reported Apache-2.0 for an MIT package.
+README_CREDITING_A_DEPENDENCY = [
+    {"detected_license": "Apache-2.0", "confidence": 1.0, "detection_method": "tag",
+     "category": "declared", "match_type": "spdx_identifier"},
+    {"detected_license": "Apache-2.0", "confidence": 0.9, "detection_method": "keyword",
+     "category": "detected", "match_type": "keyword"},
+    {"detected_license": "Apache-2.0", "confidence": 0.867, "detection_method": "regex",
+     "category": "declared", "match_type": "documentation"},
+]
+
+
 class TestAMentionIsNotADeclaration:
-    """osslili labels a pattern match in any .md/.rst/.txt/.adoc file
-    "declared" with match_type "documentation"."""
+    """In a document, a licence named inside a sentence proves nothing."""
 
-    def test_a_readme_mentioning_mit_is_not_reported(self):
-        assert not is_reportable(
-            {"detected_license": "MIT", "confidence": 0.7,
-             "detection_method": "regex", "category": "declared",
-             "match_type": "documentation"}
-        )
-
-    def test_not_through_a_real_scan_either(self):
-        with patch("subprocess.run", return_value=_result([
-            {"detected_license": "MIT", "confidence": 0.7,
-             "detection_method": "regex", "category": "declared",
-             "match_type": "documentation"}
-        ])):
-            found = OssliliSubprocessDetector().detect_from_file("README.md", MIT_TEXT)
+    def test_the_evidence_osslili_really_returns_for_a_mention(self):
+        with patch("subprocess.run",
+                   return_value=_result(README_CREDITING_A_DEPENDENCY)):
+            found = OssliliSubprocessDetector().detect_from_file(
+                "README.md", MIT_TEXT
+            )
         assert found == []
 
-    def test_but_a_high_score_still_carries_it(self):
-        """A near-exact text match is a licence however the file is named."""
+    def test_the_exact_tag_clause_does_not_rescue_it(self):
+        """confidence 1.0 and detection_method tag, and still not a licence,
+        because of where it was found."""
+        assert not is_reportable(
+            README_CREDITING_A_DEPENDENCY[0], source_file="README.md"
+        )
+
+    def test_a_partial_pattern_match_is_not_one_either(self):
+        assert not is_reportable(
+            README_CREDITING_A_DEPENDENCY[2], source_file="README.md"
+        )
+
+    def test_but_a_line_that_exists_to_state_the_licence_is(self):
+        """A real SPDX-License-Identifier or License: line. osslili reports
+        those as header_tag, which is how they are told from prose."""
         assert is_reportable(
-            {"detected_license": "MIT", "confidence": 0.99,
+            {"detected_license": "MIT", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "header_tag"},
+            source_file="README.md",
+        )
+
+    def test_and_outside_a_document_the_same_evidence_counts(self):
+        """The rule is about where the evidence was found, nothing else."""
+        assert is_reportable(
+            README_CREDITING_A_DEPENDENCY[0], source_file="package.json"
+        )
+
+
+class TestTheScoreBoundary:
+    """osslili caps a documentation match at exactly 0.95, which is also the
+    score this gate accepts on its own. Pinned so the comparison cannot drift
+    from >= to > unnoticed."""
+
+    def test_the_threshold_itself_is_enough(self):
+        assert is_reportable(
+            {"detected_license": "MIT", "confidence": 0.95,
+             "detection_method": "keyword", "category": "detected",
+             "match_type": "keyword"}
+        )
+
+    def test_just_under_is_not(self):
+        assert not is_reportable(
+            {"detected_license": "MIT", "confidence": 0.94,
+             "detection_method": "keyword", "category": "detected",
+             "match_type": "keyword"}
+        )
+
+    def test_and_in_a_document_the_score_does_not_open_the_door(self):
+        """The cap and the threshold being equal would otherwise let every
+        capped documentation match back in through the score."""
+        assert not is_reportable(
+            {"detected_license": "MIT", "confidence": 0.95,
              "detection_method": "regex", "category": "declared",
-             "match_type": "documentation"}
+             "match_type": "documentation"},
+            source_file="README.md",
         )
 
 

--- a/tests/unit/test_the_osslili_we_depend_on.py
+++ b/tests/unit/test_the_osslili_we_depend_on.py
@@ -75,3 +75,51 @@ def test_a_path_ahead_of_the_environment_does_not_win(tmp_path, monkeypatch):
     assert OssliliSubprocessDetector().detect_from_file(
         "LICENSE", "SPDX-License-Identifier: MIT\n"
     )
+
+
+class TestSomethingUnrunnableBesideTheInterpreter:
+    """Existing is not the same as runnable. Taking an unrunnable candidate
+    means the subprocess raises, the broad except swallows it, and the package
+    is reported as having no licence rather than falling back to PATH."""
+
+    def _pretend_interpreter_lives_in(self, directory, monkeypatch):
+        fake = directory / "python"
+        fake.write_text("")
+        monkeypatch.setattr(sys, "executable", str(fake))
+
+    def test_a_directory_of_that_name_is_not_taken(self, tmp_path, monkeypatch):
+        (tmp_path / "osslili").mkdir()
+        self._pretend_interpreter_lives_in(tmp_path, monkeypatch)
+
+        assert osslili_command() != str(tmp_path / "osslili")
+
+    def test_nor_a_file_with_no_execute_bit(self, tmp_path, monkeypatch):
+        candidate = tmp_path / "osslili"
+        candidate.write_text("#!/bin/sh\nexit 0\n")
+        candidate.chmod(0o644)
+        self._pretend_interpreter_lives_in(tmp_path, monkeypatch)
+
+        assert osslili_command() != str(candidate)
+
+    def test_and_the_licence_is_still_found_through_the_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "osslili").mkdir()
+        self._pretend_interpreter_lives_in(tmp_path, monkeypatch)
+        real = Path(sys.executable).parent / "osslili"
+        if not real.exists():
+            pytest.skip("no osslili installed beside the real interpreter")
+        monkeypatch.setenv("PATH", f"{real.parent}{os.pathsep}{os.environ['PATH']}")
+
+        found = OssliliSubprocessDetector().detect_from_file(
+            "LICENSE", "SPDX-License-Identifier: MIT\n"
+        )
+        assert [lic["spdx_id"] for lic in found] == ["MIT"]
+
+    def test_a_runnable_one_is_taken(self, tmp_path, monkeypatch):
+        candidate = tmp_path / "osslili"
+        candidate.write_text("#!/bin/sh\nexit 0\n")
+        candidate.chmod(0o755)
+        self._pretend_interpreter_lives_in(tmp_path, monkeypatch)
+
+        assert osslili_command() == str(candidate)

--- a/tests/unit/test_the_osslili_we_depend_on.py
+++ b/tests/unit/test_the_osslili_we_depend_on.py
@@ -1,0 +1,77 @@
+"""upmex declares osslili as a dependency, so that is the one it must run.
+
+Invoking it by bare name asked PATH instead, and PATH answered with whatever
+copy came first. On the machine this was found, that was a system-wide 1.6.1
+rather than the 1.7.5 in the environment, and the two disagree: the same
+LICENSE file holding the MIT text is MIT to one and JSON to the other. Which
+licence a package appears to have must not depend on PATH order.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from upmex.licenses.osslili_subprocess import (
+    OssliliSubprocessDetector,
+    osslili_command,
+)
+
+
+def test_it_is_the_one_installed_beside_the_interpreter():
+    beside = Path(sys.executable).parent / "osslili"
+    if not beside.exists():
+        pytest.skip("no osslili installed beside this interpreter")
+    assert osslili_command() == str(beside)
+
+
+def test_it_is_not_a_bare_name():
+    """A bare name is resolved by PATH at the moment of the call."""
+    beside = Path(sys.executable).parent / "osslili"
+    if not beside.exists():
+        pytest.skip("no osslili installed beside this interpreter")
+    assert os.path.isabs(osslili_command())
+
+
+def test_the_detector_actually_runs_it():
+    command = osslili_command()
+    result = subprocess.run(
+        [command, "--version"], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stderr
+
+    scanned = []
+    original = subprocess.run
+
+    def record(cmd, **kwargs):
+        scanned.append(cmd[0])
+        return original(cmd, **kwargs)
+
+    import upmex.licenses.osslili_subprocess as module
+
+    module.subprocess.run = record
+    try:
+        module.OssliliSubprocessDetector().detect_from_file("LICENSE", "MIT License\n")
+    finally:
+        module.subprocess.run = original
+
+    assert scanned == [command], scanned
+
+
+def test_a_path_ahead_of_the_environment_does_not_win(tmp_path, monkeypatch):
+    """The failure as it happened: another osslili earlier on PATH."""
+    impostor = tmp_path / "osslili"
+    impostor.write_text("#!/bin/sh\necho impostor\n")
+    impostor.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+
+    beside = Path(sys.executable).parent / "osslili"
+    if not beside.exists():
+        pytest.skip("no osslili installed beside this interpreter")
+
+    assert osslili_command() != str(impostor)
+    assert OssliliSubprocessDetector().detect_from_file(
+        "LICENSE", "SPDX-License-Identifier: MIT\n"
+    )


### PR DESCRIPTION
Six commits. The first fixes the root cause; the rest fix what it was hiding.

## upmex was running a different osslili than the one it depends on

It declares `osslili` as a dependency and then invoked it by bare name, so `PATH` decided which copy answered. On the machine where this was found, a system-wide **1.6.1** sat ahead of the **1.7.5** installed in the environment, and the two disagree on the same input:

| | verdict on a LICENSE file holding the MIT text |
|---|---|
| osslili 1.6.1 | `JSON 0.983 tlsh` |
| osslili 1.7.5 | `MIT 0.997 license_file` |

Which licence a package appears to have should not depend on `PATH` order. It now runs the copy installed beside its own interpreter, falling back to `PATH` only when there is none, and only when that copy is actually runnable.

That single fix corrects three real packages:

| package | before | after | correct |
|---|---|---|---|
| urllib3 | JSON, MIT | **MIT** | MIT |
| click | BSD-3-Clause, BSD-4-Clause | **BSD-3-Clause** | BSD-3-Clause |
| flask | BSD-3-Clause, BSD-4-Clause | **BSD-3-Clause** | BSD-3-Clause |

It also closes #114, which turned out to be a 1.6.1 defect visible only because the wrong binary answered.

## osslili classifies evidence by filename, and upmex was throwing the filename away

`detect_from_file` wrote the content to a random `tmpXXXX.txt`. osslili decides what kind of evidence a match is partly from the name, so a package's own `LICENSE` was read as a passing mention in a text file:

| the file osslili sees | verdict |
|---|---|
| `LICENSE` | `1.0 license_file` |
| `tmpXXXX.txt` | `0.6 to 0.95 documentation` |

The score in the second row moves with the similarity backend, which is why three NuGet tests passed locally and failed in CI. The temp file now keeps the caller's basename.

## A document mentioning a licence is not a package declaring one

osslili's SPDX patterns match prose, and its header rule matches `License: X` anywhere in the first thirty lines, mid-sentence included. So this README sentence:

> The bundled minifier is licensed under the Apache License, Version 2.0.

arrived as `detection_method: tag`, `confidence: 1.0`, `category: declared` — identical to a real `SPDX-License-Identifier` line. **An MIT package was reported as Apache-2.0** on the strength of a sentence crediting a dependency, from both the file scan and the directory scan. A credits table did it several times over.

Inside a document, what counts now is only what a mention cannot fake:

| evidence | in a document |
|---|---|
| `license_file`, `exact_hash` | accepted at any score, they identify the file itself |
| `text_similarity` | accepted at 0.95 and above |
| `spdx_identifier`, `header_tag` | refused, both match prose |
| `license_header` | refused, osslili emits it at 0.6 for a one-sentence credit |
| `documentation` | refused, see below |

`documentation` is refused because its score is not comparable between osslili's two modes. Scanning one file, a mention scores 0.6 and a document carrying the whole licence scores 0.95. Scanning a directory, osslili measures a short window around the word "license" instead, and there the same mention also scores 0.95. No threshold separates them in both modes.

Documents are recognised by suffix or by name, so a bare `README`, `INSTALL` or `CHANGELOG` counts. A licence file is never a document, whatever it is called: `LICENSE.txt`, `LICENSE-MIT.txt`, `MIT-LICENSE.md`, `COPYING`, `LEGAL.txt` and bare names like `MIT.txt` beside `APACHE.txt` all still hold the thing itself.

### What this gives up, deliberately

A package whose only licence statement is prose in its README, with no licence file and nothing in its metadata, reads as unlicensed when a **directory** is scanned. Reporting a dependency's licence as the package's own is the worse of the two errors. It is pinned in `TestWhatThisRuleGivesUp` so it is a decision on the record rather than a surprise.

## Also

- A bundled third-party licence and a referenced licence are refused ahead of any score. Previously a third-party notice scoring 0.95 became the package's licence.
- The directory scan judges evidence before deduplicating. osslili sorts by score, so a rejected record could stand in for an acceptable one behind it, and which arrived first depended on the machine.
- A path with no usable basename produced a write error that the broad except turned into a silent empty result.
- Paths carrying a Windows separator are read as paths. nuspec declarations and archive members use them.

## Verification

525 tests pass, 2 skipped. The licence tests run the real binary rather than a mock, because the central defect here was invisible to mocks: the evidence written into a test was not the evidence osslili emits.

Twenty mutations were applied across the rule and every one is caught, including reordering the checks inside the gate, moving the threshold in either direction, and reverting the judge-before-dedup fix.

Extraction across all 15 package types succeeds. Licences on 25 real packages are identical to main apart from the three corrections above.