### PR TITLE
Read the same package the same way twice

### DIFF
--- a/src/upmex/extractors/base.py
+++ b/src/upmex/extractors/base.py
@@ -1,6 +1,7 @@
 """Base extractor class for all package types."""
 
 import logging
+from collections import Counter
 from ..config import path_setting
 import hashlib
 import os
@@ -25,6 +26,47 @@ from ..utils.author_parser import parse_author_string, parse_author_list
 from ..utils.archive_utils import find_file_in_archive, extract_from_tar, extract_from_zip
 
 logger = logging.getLogger(__name__)
+
+
+# How many statements the joined copyright summary carries. The list of
+# authors is not capped: that one has to be complete.
+MAX_COPYRIGHT_STATEMENTS = 10
+
+
+def _in_a_settled_order(copyrights):
+    """Put copyright records in an order that does not change between runs.
+
+    osslili extracts them concurrently, so the same directory comes back in a
+    different order each time. That order decided which statements survived
+    the cap below and which holder was listed first, so the same package
+    reported a different author from one run to the next and its record could
+    not be compared with itself.
+
+    Ordered by how much of the package each holder accounts for, then by the
+    statement. Sorting on the statement alone is stable but says the package
+    belongs to whoever comes first alphabetically, which for a Go module put
+    a vendored "Copyright 2009 The Go Authors" ahead of the people who wrote
+    it. A holder named across many files is the one whose package this is.
+
+    Not ordered by the file. That is the one part of the record that is not
+    stable: osslili reports each distinct statement once and attaches
+    whichever file reached it first, so the same statement comes back against
+    gin_test.go on one run and utils_test.go on the next.
+    """
+    holdings = Counter(
+        str(copyright_info.get('holder') or '')
+        for copyright_info in copyrights
+    )
+
+    def by_weight(copyright_info):
+        holder = str(copyright_info.get('holder') or '')
+        return (
+            -holdings[holder],
+            holder,
+            str(copyright_info.get('statement') or ''),
+        )
+
+    return sorted(copyrights, key=by_weight)
 
 
 class BaseExtractor(ABC):
@@ -313,36 +355,43 @@ class BaseExtractor(ABC):
 
             result = detect_licenses_and_copyrights_from_directory(directory_path)
             if isinstance(result, dict) and 'copyrights' in result:
-                copyrights = result['copyrights']
+                copyrights = _in_a_settled_order(result['copyrights'])
 
-                # Combine unique copyright statements
+                # Every holder, not the first ten of them. The list of people
+                # a package credits is the part that has to be complete; the
+                # joined string below is a summary and can be cut short.
+                seen_holders = set()
+                for copyright_info in copyrights:
+                    holder = copyright_info.get('holder', '')
+                    if not (merge_with_authors and metadata and holder):
+                        continue
+                    if holder in seen_holders:
+                        continue
+                    seen_holders.add(holder)
+                    existing_names = {
+                        author.get('name', '').lower()
+                        for author in metadata.authors
+                    }
+                    if holder.lower() not in existing_names:
+                        metadata.authors.append({
+                            'name': holder,
+                            'source': 'copyright'
+                        })
+
                 unique_statements = []
                 seen_statements = set()
-                seen_holders = set()
-
-                for copyright_info in copyrights[:10]:  # Limit to first 10 to avoid huge strings
+                for copyright_info in copyrights:
                     statement = copyright_info.get('statement', '')
-                    holder = copyright_info.get('holder', '')
-
                     if statement and statement not in seen_statements:
                         unique_statements.append(statement)
                         seen_statements.add(statement)
 
-                    # If merge_with_authors is enabled and we have metadata, add holders as authors
-                    if merge_with_authors and metadata and holder and holder not in seen_holders:
-                        seen_holders.add(holder)
-                        # Check if holder is not already in authors
-                        existing_names = {author.get('name', '').lower() for author in metadata.authors}
-                        if holder.lower() not in existing_names:
-                            # Add copyright holder as author
-                            metadata.authors.append({
-                                'name': holder,
-                                'source': 'copyright'
-                            })
-
-                # Join statements with semicolons
                 if unique_statements:
-                    return '; '.join(unique_statements)
+                    # Cut after deduplicating and ordering, so the same
+                    # statements survive every time. Cutting first meant a
+                    # package with eleven of them dropped a different one on
+                    # each run.
+                    return '; '.join(unique_statements[:MAX_COPYRIGHT_STATEMENTS])
         except Exception as e:
             # Copyright extraction is optional, but the reason it failed is
             # not: discarding it left no way to tell a missing statement from

--- a/src/upmex/extractors/base.py
+++ b/src/upmex/extractors/base.py
@@ -42,31 +42,44 @@ def _in_a_settled_order(copyrights):
     reported a different author from one run to the next and its record could
     not be compared with itself.
 
-    Ordered by how much of the package each holder accounts for, then by the
-    statement. Sorting on the statement alone is stable but says the package
-    belongs to whoever comes first alphabetically, which for a Go module put
-    a vendored "Copyright 2009 The Go Authors" ahead of the people who wrote
-    it. A holder named across many files is the one whose package this is.
+    Ordered by how many distinct copyright statements name each holder, then
+    by holder and statement. Sorting on the statement alone is stable but
+    says the package belongs to whoever comes first alphabetically, which for
+    a Go module put a vendored "Copyright 2009 The Go Authors" ahead of the
+    people who wrote it.
+
+    Distinct statements, not files: osslili reports each statement once
+    however many files carry it, so the number of files a holder appears in
+    is not in the record and cannot be counted. What this measures is how
+    many years a holder has been claiming copyright here, which a long-lived
+    project accumulates and a vendored file rarely does. It is a heuristic
+    for which holder the package belongs to, and it is only used to order
+    them; every holder is reported either way.
 
     Not ordered by the file. That is the one part of the record that is not
-    stable: osslili reports each distinct statement once and attaches
-    whichever file reached it first, so the same statement comes back against
-    gin_test.go on one run and utils_test.go on the next.
+    stable: osslili attaches whichever file reached a statement first, so the
+    same statement comes back against gin_test.go on one run and
+    utils_test.go on the next.
     """
-    holdings = Counter(
-        str(copyright_info.get('holder') or '')
-        for copyright_info in copyrights
-    )
-
-    def by_weight(copyright_info):
-        holder = str(copyright_info.get('holder') or '')
-        return (
-            -holdings[holder],
-            holder,
+    # Records identical in holder and statement are the same claim, and
+    # nothing downstream can tell them apart. Dropping them here is what
+    # makes the order total: leaving them in, two records that tie on every
+    # key hold whatever order they arrived in.
+    distinct = {}
+    for copyright_info in copyrights:
+        key = (
+            str(copyright_info.get('holder') or ''),
             str(copyright_info.get('statement') or ''),
         )
+        distinct.setdefault(key, copyright_info)
 
-    return sorted(copyrights, key=by_weight)
+    statements_per_holder = Counter(holder for holder, _ in distinct)
+
+    def by_weight(item):
+        (holder, statement), _ = item
+        return (-statements_per_holder[holder], holder, statement)
+
+    return [record for _, record in sorted(distinct.items(), key=by_weight)]
 
 
 class BaseExtractor(ABC):

--- a/src/upmex/extractors/base.py
+++ b/src/upmex/extractors/base.py
@@ -42,19 +42,22 @@ def _in_a_settled_order(copyrights):
     reported a different author from one run to the next and its record could
     not be compared with itself.
 
-    Ordered by how many distinct copyright statements name each holder, then
-    by holder and statement. Sorting on the statement alone is stable but
-    says the package belongs to whoever comes first alphabetically, which for
-    a Go module put a vendored "Copyright 2009 The Go Authors" ahead of the
-    people who wrote it.
+    Ordered by how many years each holder has been claiming copyright here,
+    then by holder and statement. Sorting on the statement alone is stable
+    but says the package belongs to whoever comes first alphabetically, which
+    for a Go module put a vendored "Copyright 2009 The Go Authors" ahead of
+    the people who wrote it.
 
-    Distinct statements, not files: osslili reports each statement once
-    however many files carry it, so the number of files a holder appears in
-    is not in the record and cannot be counted. What this measures is how
-    many years a holder has been claiming copyright here, which a long-lived
-    project accumulates and a vendored file rarely does. It is a heuristic
-    for which holder the package belongs to, and it is only used to order
-    them; every holder is reported either way.
+    Years, not statements: a project writing "Copyright 2013-2023" makes one
+    statement covering eleven years, and counting statements ranked it below
+    a third-party file carrying two. osslili expands a range, so the years
+    are there to count.
+
+    Not files, which would be the better signal: osslili reports each
+    statement once however many files carry it, so the number of files a
+    holder appears in is not in the record. This is a heuristic for whose
+    package this is, it is used only to order the holders, and every one of
+    them is reported either way.
 
     Not ordered by the file. That is the one part of the record that is not
     stable: osslili attaches whichever file reached a statement first, so the
@@ -73,11 +76,24 @@ def _in_a_settled_order(copyrights):
         )
         distinct.setdefault(key, copyright_info)
 
+    years_per_holder = {}
+    for (holder, _), record in distinct.items():
+        years = record.get('years') or []
+        years_per_holder.setdefault(holder, set()).update(
+            year for year in years if isinstance(year, int)
+        )
     statements_per_holder = Counter(holder for holder, _ in distinct)
 
     def by_weight(item):
         (holder, statement), _ = item
-        return (-statements_per_holder[holder], holder, statement)
+        return (
+            -len(years_per_holder.get(holder, ())),
+            # A record with no years at all falls back to how many separate
+            # claims the holder makes, which is what this counted before.
+            -statements_per_holder[holder],
+            holder,
+            statement,
+        )
 
     return [record for _, record in sorted(distinct.items(), key=by_weight)]
 

--- a/src/upmex/extractors/gradle_extractor.py
+++ b/src/upmex/extractors/gradle_extractor.py
@@ -297,4 +297,7 @@ class GradleExtractor(BaseExtractor):
                 tags = re.findall(r'["\']([^"\']+)["\']', tags_str)
                 keywords.extend(tags)
         
-        return list(set(keywords)) if keywords else []
+        # Ordered, because a set's order depends on the hash seed and this
+        # list is published. The same build file gave different keyword
+        # orders in different processes.
+        return sorted(set(keywords)) if keywords else []

--- a/src/upmex/extractors/perl_extractor.py
+++ b/src/upmex/extractors/perl_extractor.py
@@ -54,7 +54,7 @@ class PerlExtractor(BaseExtractor):
                 tar.extractall(temp_dir)
             
             # Find the extracted directory
-            extracted_dirs = [d for d in os.listdir(temp_dir) 
+            extracted_dirs = [d for d in sorted(os.listdir(temp_dir)) 
                             if os.path.isdir(os.path.join(temp_dir, d))]
             
             if extracted_dirs:
@@ -79,7 +79,7 @@ class PerlExtractor(BaseExtractor):
                 zip_ref.extractall(temp_dir)
             
             # Find the extracted directory
-            extracted_dirs = [d for d in os.listdir(temp_dir) 
+            extracted_dirs = [d for d in sorted(os.listdir(temp_dir)) 
                             if os.path.isdir(os.path.join(temp_dir, d))]
             
             if extracted_dirs:
@@ -400,7 +400,7 @@ class PerlExtractor(BaseExtractor):
             else:
                 # Check pattern match
                 base_pattern = pattern.replace('.*', '')
-                for file_name in os.listdir(package_dir):
+                for file_name in sorted(os.listdir(package_dir)):
                     if file_name.startswith(base_pattern):
                         file_path = os.path.join(package_dir, file_name)
                         if os.path.isfile(file_path):

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -461,7 +461,23 @@ class OssliliSubprocessDetector:
         except Exception as e:
             logger.debug(f"Osslili subprocess directory detection failed for {dir_path}: {e}")
             
-        return {"licenses": licenses, "copyrights": copyrights}
+        return {
+            # Ordered before publishing. osslili scans concurrently and sorts
+            # its evidence by confidence, so two licences of equal confidence
+            # keep whatever order the threads finished in, and this list is
+            # assigned straight into a package's record by the Debian
+            # extractor. Best evidence first, which is what osslili intends,
+            # and settled beyond that.
+            "licenses": sorted(
+                licenses,
+                key=lambda lic: (
+                    -float(lic.get('confidence') or 0),
+                    str(lic.get('spdx_id') or ''),
+                    str(lic.get('file') or ''),
+                ),
+            ),
+            "copyrights": copyrights,
+        }
 
     # A match is exact when the file says which licence it is, not when a
     # similarity score is close to one. osslili reports which of those it did.

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -444,10 +444,15 @@ class OssliliSubprocessDetector:
                         
                         licenses.append(license_info)
                 elif 'results' in data and data['results']:
-                    # Fallback to old format
-                    for result_item in data['results']:
-                        if 'licenses' in result_item:
-                            for lic in result_item['licenses']:
+                    # Ordered before the deduplication for the same
+                    # reason as the current format above. Reachable only
+                    # with an osslili old enough to emit it, and wrong in
+                    # the same way without this.
+                    for lic in _strongest_first([
+                            evidence
+                            for result_item in data['results']
+                            for evidence in result_item.get('licenses', [])
+                    ]):
                                 # Create unique key to avoid duplicates
                                 if not is_reportable(lic):
                                     continue

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -401,42 +401,48 @@ class OssliliSubprocessDetector:
                 seen_licenses = set()
                 # Handle both 'scan_results' format (newer) and 'results' format (older)
                 if 'scan_results' in data and data['scan_results']:
-                    for scan_result in data['scan_results']:
-                        if 'license_evidence' in scan_result:
-                            for lic in _strongest_first(scan_result['license_evidence']):
-                                # Map detected_license to spdx_id for consistency
-                                spdx_id = lic.get('detected_license', lic.get('spdx_id', 'Unknown'))
-                                # Judge before deduplicating. osslili sorts
-                                # evidence by score, so keying on the first
-                                # record for a (licence, file) pair let a
-                                # rejected one stand in for an acceptable one
-                                # behind it, and which came first depended on
-                                # the machine.
-                                if not is_reportable(lic, spdx_id):
-                                    continue
-                                key = (spdx_id, lic.get('file', 'unknown'))
-                                if key in seen_licenses:
-                                    continue
-                                seen_licenses.add(key)
-                                
-                                license_info = {
-                                    "name": lic.get('name', spdx_id),
-                                    "spdx_id": spdx_id,
-                                    "confidence": lic.get('confidence', 0.0),
-                                    "confidence_level": self._get_confidence_level(
-                                        lic.get('confidence', 0.0),
-                                        lic.get('detection_method', ''),
-                                        lic.get('match_type', ''),
-                                    ),
-                                    "source": f"osslili_{lic.get('detection_method', 'unknown')}",
-                                    # Scanning a directory, so this really is
-                                    # the file osslili read.
-                                    "file": lic.get('file', 'unknown'),
-                                    "category": lic.get('category'),
-                                    "match_type": lic.get('match_type'),
-                                }
-                                
-                                licenses.append(license_info)
+                    # Flattened across every scan result before ordering,
+                    # because the deduplication below is global. Ordering
+                    # each result on its own said nothing about two records
+                    # for the same licence arriving in different results.
+                    for lic in _strongest_first([
+                            evidence
+                            for scan_result in data['scan_results']
+                            for evidence in scan_result.get('license_evidence', [])
+                    ]):
+                        # Map detected_license to spdx_id for consistency
+                        spdx_id = lic.get('detected_license', lic.get('spdx_id', 'Unknown'))
+                        # Judge before deduplicating. osslili sorts
+                        # evidence by score, so keying on the first
+                        # record for a (licence, file) pair let a
+                        # rejected one stand in for an acceptable one
+                        # behind it, and which came first depended on
+                        # the machine.
+                        if not is_reportable(lic, spdx_id):
+                            continue
+                        key = (spdx_id, lic.get('file', 'unknown'))
+                        if key in seen_licenses:
+                            continue
+                        seen_licenses.add(key)
+                        
+                        license_info = {
+                            "name": lic.get('name', spdx_id),
+                            "spdx_id": spdx_id,
+                            "confidence": lic.get('confidence', 0.0),
+                            "confidence_level": self._get_confidence_level(
+                                lic.get('confidence', 0.0),
+                                lic.get('detection_method', ''),
+                                lic.get('match_type', ''),
+                            ),
+                            "source": f"osslili_{lic.get('detection_method', 'unknown')}",
+                            # Scanning a directory, so this really is
+                            # the file osslili read.
+                            "file": lic.get('file', 'unknown'),
+                            "category": lic.get('category'),
+                            "match_type": lic.get('match_type'),
+                        }
+                        
+                        licenses.append(license_info)
                 elif 'results' in data and data['results']:
                     # Fallback to old format
                     for result_item in data['results']:
@@ -474,25 +480,25 @@ class OssliliSubprocessDetector:
                 # Extract copyrights from scan_results
                 seen_copyrights = set()
                 if 'scan_results' in data and data['scan_results']:
-                    logger.debug(f"DEBUG: Processing {len(data['scan_results'])} scan results for copyrights")
-                    for scan_result in data['scan_results']:
-                        if 'copyright_evidence' in scan_result:
-                            logger.debug(f"DEBUG: Found {len(scan_result['copyright_evidence'])} copyright items")
-                            for copyright_item in _statements_first(
-                                    scan_result['copyright_evidence']):
-                                statement = copyright_item.get('statement', '')
-                                logger.debug(f"DEBUG: Processing copyright: statement='{statement}'")
-                                if statement and statement not in seen_copyrights:
-                                    seen_copyrights.add(statement)
-                                    copyright_info = {
-                                        "statement": statement,
-                                        "holder": copyright_item.get('holder', ''),
-                                        "years": copyright_item.get('years', []),
-                                        "file": copyright_item.get('file', 'unknown'),
-                                        "confidence": copyright_item.get('confidence', 1.0)
-                                    }
-                                    copyrights.append(copyright_info)
-                                    logger.debug(f"DEBUG: Added copyright: {copyright_info}")
+                    # Flattened for the same reason as the licences above.
+                    for copyright_item in _statements_first([
+                            evidence
+                            for scan_result in data['scan_results']
+                            for evidence in scan_result.get('copyright_evidence', [])
+                    ]):
+                        statement = copyright_item.get('statement', '')
+                        logger.debug(f"DEBUG: Processing copyright: statement='{statement}'")
+                        if statement and statement not in seen_copyrights:
+                            seen_copyrights.add(statement)
+                            copyright_info = {
+                                "statement": statement,
+                                "holder": copyright_item.get('holder', ''),
+                                "years": copyright_item.get('years', []),
+                                "file": copyright_item.get('file', 'unknown'),
+                                "confidence": copyright_item.get('confidence', 1.0)
+                            }
+                            copyrights.append(copyright_info)
+                            logger.debug(f"DEBUG: Added copyright: {copyright_info}")
 
             # TODO: OSSlili v1.5.0 doesn't detect "Copyright (c)" format - FIXED in v1.5.1
             # Issue filed: https://github.com/oscarvalenzuelab/osslili/issues/32

--- a/src/upmex/licenses/osslili_subprocess.py
+++ b/src/upmex/licenses/osslili_subprocess.py
@@ -187,6 +187,43 @@ def is_reportable(lic, spdx_id=None, source_file=None):
 
 
 
+def _strongest_first(evidence):
+    """Order raw licence evidence before anything picks a winner from it.
+
+    Deduplicating first and keeping whichever record arrived first meant the
+    published source and match_type came from whichever of two equally
+    confident records the scan happened to finish first, even though the
+    licence itself did not move.
+    """
+    def strength(item):
+        return (
+            -float(item.get('confidence') or 0),
+            str(item.get('detected_license') or item.get('spdx_id') or ''),
+            str(item.get('match_type') or ''),
+            str(item.get('detection_method') or ''),
+            str(item.get('file') or ''),
+        )
+
+    return sorted(evidence, key=strength)
+
+
+def _statements_first(evidence):
+    """Order raw copyright evidence for the same reason.
+
+    A caller of detect_from_directory got osslili's arrival order, and where
+    two records held the same statement the one whose file was published
+    depended on which thread finished first.
+    """
+    def claim(item):
+        return (
+            str(item.get('statement') or ''),
+            str(item.get('holder') or ''),
+            str(item.get('file') or ''),
+        )
+
+    return sorted(evidence, key=claim)
+
+
 class OssliliSubprocessDetector:
     """License detector using osslili CLI."""
     
@@ -366,7 +403,7 @@ class OssliliSubprocessDetector:
                 if 'scan_results' in data and data['scan_results']:
                     for scan_result in data['scan_results']:
                         if 'license_evidence' in scan_result:
-                            for lic in scan_result['license_evidence']:
+                            for lic in _strongest_first(scan_result['license_evidence']):
                                 # Map detected_license to spdx_id for consistency
                                 spdx_id = lic.get('detected_license', lic.get('spdx_id', 'Unknown'))
                                 # Judge before deduplicating. osslili sorts
@@ -441,7 +478,8 @@ class OssliliSubprocessDetector:
                     for scan_result in data['scan_results']:
                         if 'copyright_evidence' in scan_result:
                             logger.debug(f"DEBUG: Found {len(scan_result['copyright_evidence'])} copyright items")
-                            for copyright_item in scan_result['copyright_evidence']:
+                            for copyright_item in _statements_first(
+                                    scan_result['copyright_evidence']):
                                 statement = copyright_item.get('statement', '')
                                 logger.debug(f"DEBUG: Processing copyright: statement='{statement}'")
                                 if statement and statement not in seen_copyrights:
@@ -476,7 +514,17 @@ class OssliliSubprocessDetector:
                     str(lic.get('file') or ''),
                 ),
             ),
-            "copyrights": copyrights,
+            # Ordered for the same reason, so a caller of this function
+            # gets the same list twice rather than osslili's arrival order.
+            # Package extraction reorders them again by holder; this is what
+            # a direct caller sees.
+            "copyrights": sorted(
+                copyrights,
+                key=lambda c: (
+                    str(c.get('statement') or ''),
+                    str(c.get('holder') or ''),
+                ),
+            ),
         }
 
     # A match is exact when the file says which licence it is, not when a

--- a/tests/unit/test_the_same_package_reads_the_same_way.py
+++ b/tests/unit/test_the_same_package_reads_the_same_way.py
@@ -291,3 +291,50 @@ class TestKeywordsComeOutInAnOrder:
         )
 
         assert keywords == sorted(keywords)
+
+
+class TestADirectoryScanPublishesLicencesInAnOrder:
+    """The list goes straight into a Debian package's record. osslili scans
+    concurrently and sorts its evidence by confidence, so two licences of
+    equal confidence keep whatever order the threads finished in."""
+
+    def _scan(self, evidence):
+        from unittest.mock import patch
+
+        from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector
+
+        payload = json.dumps({
+            "scan_results": [{"license_evidence": evidence, "copyright_evidence": []}]
+        })
+
+        class Result:
+            returncode = 0
+            stderr = ""
+            stdout = payload
+
+        with patch("subprocess.run", return_value=Result()):
+            found = OssliliSubprocessDetector().detect_from_directory("/repo")
+        return [lic["spdx_id"] for lic in found["licenses"]]
+
+    def _evidence(self, *pairs):
+        return [
+            {"detected_license": spdx, "confidence": confidence,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "spdx_identifier", "file": f"/repo/LICENSE-{spdx}"}
+            for spdx, confidence in pairs
+        ]
+
+    def test_two_licences_of_equal_confidence_come_out_the_same_way(self):
+        evidence = self._evidence(("MIT", 1.0), ("Apache-2.0", 1.0))
+
+        assert self._scan(evidence) == self._scan(list(reversed(evidence)))
+
+    def test_and_the_better_evidenced_one_leads(self):
+        evidence = self._evidence(("Zlib", 0.96), ("Apache-2.0", 1.0))
+
+        assert self._scan(evidence)[0] == "Apache-2.0"
+
+    def test_however_it_arrives(self):
+        evidence = self._evidence(("Apache-2.0", 1.0), ("Zlib", 0.96))
+
+        assert self._scan(evidence)[0] == "Apache-2.0"

--- a/tests/unit/test_the_same_package_reads_the_same_way.py
+++ b/tests/unit/test_the_same_package_reads_the_same_way.py
@@ -11,6 +11,7 @@ survived a cap of ten and which holder was listed first.
 
 import hashlib
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -28,7 +29,10 @@ def _record(package):
     return json.dumps({
         "copyright": metadata.copyright,
         "authors": [author.get("name") for author in (metadata.authors or [])],
-        "licenses": sorted(lic.spdx_id for lic in (metadata.licenses or [])),
+        # Not sorted. The order licences come out in is part of the record,
+        # so sorting here would hide exactly the kind of change this is for.
+        "licenses": [lic.spdx_id for lic in (metadata.licenses or [])],
+        "keywords": metadata.keywords,
     })
 
 
@@ -189,3 +193,101 @@ class TestNothingIsLostToTheCap:
         assert len(summaries) == 1, summaries
         only = summaries.pop()
         assert len(only.split(";")) <= MAX_COPYRIGHT_STATEMENTS
+
+
+class TestTheOrderIsTotal:
+    """Two records that tie on every key would otherwise hold whatever order
+    they arrived in, which is the order this exists to replace."""
+
+    def test_identical_claims_collapse_to_one(self):
+        same = {"statement": "Copyright 2024 Same", "holder": "Same"}
+        records = [dict(same, file="/tmp/a.go"), dict(same, file="/tmp/b.go")]
+
+        settled = _in_a_settled_order(records)
+
+        assert len(settled) == 1
+
+    def test_so_reversing_the_input_changes_nothing(self):
+        same = {"statement": "Copyright 2024 Same", "holder": "Same"}
+        records = [dict(same, file="/tmp/a.go"), dict(same, file="/tmp/b.go")]
+
+        assert (
+            [r["statement"] for r in _in_a_settled_order(records)]
+            == [r["statement"] for r in _in_a_settled_order(list(reversed(records)))]
+        )
+
+    def test_a_holder_with_two_statements_still_keeps_both(self):
+        records = _statements(("Same", 2023), ("Same", 2024))
+
+        assert len(_in_a_settled_order(records)) == 2
+
+
+class TestWhatTheOrderingSignalActuallyIs:
+    """Named plainly because it is a heuristic, not a measurement. osslili
+    reports each statement once however many files carry it, so the number of
+    files a holder appears in is not in the record."""
+
+    def test_it_counts_distinct_statements_not_files(self):
+        records = [
+            {"statement": "Copyright 2024 One Liner", "holder": "One Liner",
+             "file": "/tmp/a.go"},
+            {"statement": "Copyright 2009 Many Years", "holder": "Many Years",
+             "file": "/tmp/b.go"},
+            {"statement": "Copyright 2010 Many Years", "holder": "Many Years",
+             "file": "/tmp/c.go"},
+        ]
+
+        assert _in_a_settled_order(records)[0]["holder"] == "Many Years"
+
+    def test_and_every_holder_is_reported_whatever_the_order(self):
+        records = [
+            {"statement": "Copyright 2024 One Liner", "holder": "One Liner",
+             "file": "/tmp/a.go"},
+            {"statement": "Copyright 2009 Many Years", "holder": "Many Years",
+             "file": "/tmp/b.go"},
+            {"statement": "Copyright 2010 Many Years", "holder": "Many Years",
+             "file": "/tmp/c.go"},
+        ]
+
+        holders = {r["holder"] for r in _in_a_settled_order(records)}
+
+        assert holders == {"One Liner", "Many Years"}
+
+
+class TestKeywordsComeOutInAnOrder:
+    """A set's order depends on the hash seed, and this list is published."""
+
+    def test_the_same_build_file_gives_the_same_order(self):
+        """Run in separate processes with different hash seeds, because a
+        set's order is fixed within one process and only moves between them.
+        Comparing three calls in the same process cannot see this at all."""
+        import subprocess
+        import sys
+
+        script = (
+            "import sys; sys.path.insert(0, 'src');"
+            "from upmex.extractors.gradle_extractor import GradleExtractor;"
+            "print(GradleExtractor()._extract_keywords("
+            "'tags = [\"web\", \"api\", \"cli\", \"server\", \"json\", \"tool\"]', False))"
+        )
+
+        orders = set()
+        for seed in ("0", "1", "42", "12345"):
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                cwd=REPO_ROOT, capture_output=True, text=True,
+                env={**os.environ, "PYTHONHASHSEED": seed},
+            )
+            assert result.returncode == 0, result.stderr
+            orders.add(result.stdout.strip())
+
+        assert len(orders) == 1, orders
+
+    def test_and_it_is_sorted(self, tmp_path):
+        from upmex.extractors.gradle_extractor import GradleExtractor
+
+        keywords = GradleExtractor()._extract_keywords(
+            'tags = ["web", "api", "cli"]\n', False
+        )
+
+        assert keywords == sorted(keywords)

--- a/tests/unit/test_the_same_package_reads_the_same_way.py
+++ b/tests/unit/test_the_same_package_reads_the_same_way.py
@@ -316,6 +316,29 @@ class TestADirectoryScanPublishesLicencesInAnOrder:
             found = OssliliSubprocessDetector().detect_from_directory("/repo")
         return [lic["spdx_id"] for lic in found["licenses"]]
 
+    def _scan_whole(self, evidence, copyrights=()):
+        """Every published field, not the identifier alone. Comparing only
+        the identifier missed that the source and match_type came from
+        whichever equally confident record arrived first."""
+        from unittest.mock import patch
+
+        from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector
+
+        payload = json.dumps({
+            "scan_results": [{
+                "license_evidence": evidence,
+                "copyright_evidence": list(copyrights),
+            }]
+        })
+
+        class Result:
+            returncode = 0
+            stderr = ""
+            stdout = payload
+
+        with patch("subprocess.run", return_value=Result()):
+            return OssliliSubprocessDetector().detect_from_directory("/repo")
+
     def _evidence(self, *pairs):
         return [
             {"detected_license": spdx, "confidence": confidence,
@@ -338,3 +361,84 @@ class TestADirectoryScanPublishesLicencesInAnOrder:
         evidence = self._evidence(("Apache-2.0", 1.0), ("Zlib", 0.96))
 
         assert self._scan(evidence)[0] == "Apache-2.0"
+
+    def test_the_whole_record_settles_not_only_the_identifier(self):
+        """Two equally confident records for one licence in one file. The
+        identifier never moved; the source and match_type published alongside
+        it did, because the dedupe kept whichever arrived first."""
+        evidence = [
+            {"detected_license": "MIT", "confidence": 1.0,
+             "detection_method": "tag", "category": "declared",
+             "match_type": "license_file", "file": "/repo/LICENSE"},
+            {"detected_license": "MIT", "confidence": 1.0,
+             "detection_method": "spdx_identifier", "category": "declared",
+             "match_type": "spdx_identifier", "file": "/repo/LICENSE"},
+        ]
+
+        assert (
+            self._scan_whole(evidence)["licenses"]
+            == self._scan_whole(list(reversed(evidence)))["licenses"]
+        )
+
+    def test_and_the_copyrights_a_direct_caller_gets_settle_too(self):
+        """Package extraction reorders them again, so only someone calling
+        this function sees this order. They should still see one order."""
+        copyrights = [
+            {"statement": "Copyright 2024 Same", "holder": "Same",
+             "years": [2024], "file": "/repo/a.go"},
+            {"statement": "Copyright 2024 Same", "holder": "Same",
+             "years": [2024], "file": "/repo/b.go"},
+            {"statement": "Copyright 2009 Other", "holder": "Other",
+             "years": [2009], "file": "/repo/c.go"},
+        ]
+
+        assert (
+            self._scan_whole([], copyrights)["copyrights"]
+            == self._scan_whole([], list(reversed(copyrights)))["copyrights"]
+        )
+
+    def _scan_results(self, results):
+        """osslili returns a list of scan results. Sorting the evidence
+        inside each one settles that one; the order of the list itself is a
+        second place the arrival order can show through."""
+        from unittest.mock import patch
+
+        from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector
+
+        class Result:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps({"scan_results": list(results)})
+
+        with patch("subprocess.run", return_value=Result()):
+            return OssliliSubprocessDetector().detect_from_directory("/repo")
+
+    def test_the_order_of_the_scan_results_themselves_does_not_show(self):
+        first = {
+            "license_evidence": [
+                {"detected_license": "MIT", "confidence": 1.0,
+                 "detection_method": "tag", "category": "declared",
+                 "match_type": "spdx_identifier", "file": "/repo/a/LICENSE"},
+            ],
+            "copyright_evidence": [
+                {"statement": "Copyright 2024 A", "holder": "A",
+                 "years": [2024], "file": "/repo/a/x.go"},
+            ],
+        }
+        second = {
+            "license_evidence": [
+                {"detected_license": "Apache-2.0", "confidence": 1.0,
+                 "detection_method": "tag", "category": "declared",
+                 "match_type": "spdx_identifier", "file": "/repo/b/LICENSE"},
+            ],
+            "copyright_evidence": [
+                {"statement": "Copyright 2009 B", "holder": "B",
+                 "years": [2009], "file": "/repo/b/y.go"},
+            ],
+        }
+
+        one = self._scan_results([first, second])
+        other = self._scan_results([second, first])
+
+        assert one["licenses"] == other["licenses"]
+        assert one["copyrights"] == other["copyrights"]

--- a/tests/unit/test_the_same_package_reads_the_same_way.py
+++ b/tests/unit/test_the_same_package_reads_the_same_way.py
@@ -442,3 +442,43 @@ class TestADirectoryScanPublishesLicencesInAnOrder:
 
         assert one["licenses"] == other["licenses"]
         assert one["copyrights"] == other["copyrights"]
+
+    def test_the_same_licence_in_two_scan_results_settles(self):
+        """The deduplication is global but the ordering was per result, so
+        two records for one licence arriving in different scan results still
+        let the arrival order pick which one was published."""
+        mit = {"detected_license": "MIT", "confidence": 1.0,
+               "category": "declared", "file": "/repo/LICENSE"}
+        first = {"license_evidence": [
+            dict(mit, detection_method="tag", match_type="license_file")]}
+        second = {"license_evidence": [
+            dict(mit, detection_method="spdx_identifier",
+                 match_type="spdx_identifier")]}
+
+        assert (
+            self._scan_results([first, second])["licenses"]
+            == self._scan_results([second, first])["licenses"]
+        )
+
+    def test_the_same_statement_in_two_scan_results_settles_too(self):
+        same = {"statement": "Copyright 2024 Same", "holder": "Same",
+                "years": [2024]}
+        first = {"copyright_evidence": [dict(same, file="/repo/a.go")]}
+        second = {"copyright_evidence": [dict(same, file="/repo/b.go")]}
+
+        assert (
+            self._scan_results([first, second])["copyrights"]
+            == self._scan_results([second, first])["copyrights"]
+        )
+
+    def test_and_the_file_published_with_it_is_the_same_one(self):
+        """The identifier never moved. What moved was the record around it."""
+        same = {"statement": "Copyright 2024 Same", "holder": "Same",
+                "years": [2024]}
+        first = {"copyright_evidence": [dict(same, file="/repo/a.go")]}
+        second = {"copyright_evidence": [dict(same, file="/repo/b.go")]}
+
+        one = self._scan_results([first, second])["copyrights"]
+        other = self._scan_results([second, first])["copyrights"]
+
+        assert [c["file"] for c in one] == [c["file"] for c in other]

--- a/tests/unit/test_the_same_package_reads_the_same_way.py
+++ b/tests/unit/test_the_same_package_reads_the_same_way.py
@@ -482,3 +482,161 @@ class TestADirectoryScanPublishesLicencesInAnOrder:
         other = self._scan_results([second, first])["copyrights"]
 
         assert [c["file"] for c in one] == [c["file"] for c in other]
+
+
+class TestTheRecordDoesNotMoveWithTheHashSeed:
+    """The test above extracts twice inside one pytest process, which shares
+    one hash seed, so anything ordered by a set looks settled to it.
+
+    Replacing the author merge with a loop over a set of holders passed all
+    700 tests and still gave gin four different author orders across four
+    seeds. That is the bug this file is named for, green suite and all.
+    """
+
+    def _record_under(self, seed, package):
+        import subprocess
+        import sys
+
+        script = (
+            "import sys, json, warnings, logging;"
+            "warnings.filterwarnings('ignore'); logging.disable(logging.CRITICAL);"
+            "sys.path.insert(0, 'src');"
+            "from upmex.core.extractor import PackageExtractor;"
+            f"m = PackageExtractor().extract({str(package)!r});"
+            "print(json.dumps({"
+            "'copyright': m.copyright,"
+            "'authors': [a.get('name') for a in (m.authors or [])],"
+            "'licenses': [l.spdx_id for l in (m.licenses or [])],"
+            "'keywords': m.keywords}))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+            env={**os.environ, "PYTHONHASHSEED": str(seed)},
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout.strip()
+
+    @pytest.mark.parametrize("package", [
+        # The one that was unstable, and one with several copyright holders.
+        "gin-v1.10.0.zip",
+        "cobra-v1.8.1.zip",
+    ])
+    def test_four_seeds_give_one_record(self, package):
+        path = PACKAGES / package
+        records = {self._record_under(seed, path) for seed in (0, 1, 5, 7)}
+
+        assert len(records) == 1, records
+
+
+class TestTheHolderWithTheLongestClaimLeads:
+    """Counting statements ranked a project writing one line covering eleven
+    years below a third-party file carrying two. osslili expands a range, so
+    the years are there to count."""
+
+    def test_a_range_outweighs_two_separate_claims(self):
+        records = [
+            {"statement": "Copyright 2013-2023 The Project",
+             "holder": "The Project", "years": list(range(2013, 2024))},
+            {"statement": "Copyright 2009 Third Party",
+             "holder": "Third Party", "years": [2009]},
+            {"statement": "Copyright 2010 Third Party",
+             "holder": "Third Party", "years": [2010]},
+        ]
+
+        assert _in_a_settled_order(records)[0]["holder"] == "The Project"
+
+    def test_however_the_records_arrive(self):
+        records = [
+            {"statement": "Copyright 2009 Third Party",
+             "holder": "Third Party", "years": [2009]},
+            {"statement": "Copyright 2010 Third Party",
+             "holder": "Third Party", "years": [2010]},
+            {"statement": "Copyright 2013-2023 The Project",
+             "holder": "The Project", "years": list(range(2013, 2024))},
+        ]
+
+        assert _in_a_settled_order(records)[0]["holder"] == "The Project"
+
+    def test_a_holder_claiming_more_years_leads(self):
+        records = [
+            {"statement": "Copyright 2009 Brief", "holder": "Brief",
+             "years": [2009]},
+            {"statement": "Copyright 2018 Long", "holder": "Long",
+             "years": [2018]},
+            {"statement": "Copyright 2019 Long", "holder": "Long",
+             "years": [2019]},
+        ]
+
+        assert _in_a_settled_order(records)[0]["holder"] == "Long"
+
+    def test_records_with_no_years_fall_back_to_counting_claims(self):
+        """Named so that the alphabet disagrees with the claim count. With
+        names where they agree, dropping the fallback entirely still passes."""
+        records = [
+            {"statement": "Copyright Alpha", "holder": "Alpha"},
+            {"statement": "Copyright A Zed", "holder": "Zed"},
+            {"statement": "Copyright B Zed", "holder": "Zed"},
+        ]
+
+        assert _in_a_settled_order(records)[0]["holder"] == "Zed"
+
+    def test_and_a_holder_with_years_still_beats_one_with_more_claims(self):
+        """The years come first, so one dated claim outranks two undated
+        ones however many there are."""
+        records = [
+            {"statement": "Copyright 2009 Dated", "holder": "Dated",
+             "years": [2009]},
+            {"statement": "Copyright A Undated", "holder": "Undated"},
+            {"statement": "Copyright B Undated", "holder": "Undated"},
+        ]
+
+        assert _in_a_settled_order(records)[0]["holder"] == "Dated"
+
+    def test_and_a_real_package_reads_the_way_it_should(self):
+        """cobra states one range and nothing else, so counting statements
+        gave it no weight at all."""
+        metadata = PackageExtractor().extract(str(PACKAGES / "cobra-v1.8.1.zip"))
+
+        assert metadata.authors
+        assert metadata.authors[0]["name"] == "The Cobra Authors"
+
+
+class TestTheOlderOutputFormatSettlesToo:
+    """Reachable only with an osslili old enough to emit it, and wrong in the
+    same way without ordering."""
+
+    def _scan(self, licences):
+        from unittest.mock import patch
+
+        from upmex.licenses.osslili_subprocess import OssliliSubprocessDetector
+
+        class Result:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps({"results": [{"licenses": list(licences)}]})
+
+        with patch("subprocess.run", return_value=Result()):
+            return OssliliSubprocessDetector().detect_from_directory("/repo")
+
+    def test_equal_evidence_comes_out_the_same_way(self):
+        licences = [
+            {"spdx_id": "MIT", "confidence": 1.0, "detection_method": "tag",
+             "source_file": "/repo/LICENSE"},
+            {"spdx_id": "MIT", "confidence": 1.0,
+             "detection_method": "spdx_identifier", "source_file": "/repo/LICENSE"},
+        ]
+
+        assert self._scan(licences) == self._scan(list(reversed(licences)))
+
+
+class TestADirectoryIsWalkedInAnOrder:
+    """os.listdir returns whatever the filesystem gives, which is stable on
+    one machine and not guaranteed between them."""
+
+    def test_the_perl_extractor_does_not_walk_unordered(self):
+        source = (REPO_ROOT / "src" / "upmex" / "extractors"
+                  / "perl_extractor.py").read_text()
+
+        assert "sorted(os.listdir(" in source
+        assert source.count("os.listdir(") == source.count("sorted(os.listdir(")

--- a/tests/unit/test_the_same_package_reads_the_same_way.py
+++ b/tests/unit/test_the_same_package_reads_the_same_way.py
@@ -1,0 +1,191 @@
+"""The same package has to produce the same record.
+
+upmex reported a different author for the same file from one run to the next,
+and a different set of copyright statements. A record whose content depends on
+the run cannot be compared with itself, diffed in CI, or attested to.
+
+The cause was osslili extracting copyright statements concurrently: the order
+it returns them in changes every time. That order decided which statements
+survived a cap of ten and which holder was listed first.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from upmex.core.extractor import PackageExtractor
+from upmex.core.models import PackageMetadata, PackageType
+from upmex.extractors.base import _in_a_settled_order
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGES = REPO_ROOT / "test-packages"
+
+
+def _record(package):
+    metadata = PackageExtractor().extract(str(package))
+    return json.dumps({
+        "copyright": metadata.copyright,
+        "authors": [author.get("name") for author in (metadata.authors or [])],
+        "licenses": sorted(lic.spdx_id for lic in (metadata.licenses or [])),
+    })
+
+
+def _statements(*holders):
+    """Records shaped like osslili's, with the file deliberately varied.
+
+    osslili reports each distinct statement once and attaches whichever file
+    reached it first, so the same statement comes back against one file on one
+    run and another on the next. Anything that sorts on the file inherits that.
+    """
+    return [
+        {"statement": f"Copyright {year} {holder}",
+         "holder": holder,
+         "years": [year],
+         "file": f"/tmp/{index}/some_test.go"}
+        for index, (holder, year) in enumerate(holders)
+    ]
+
+
+class TestTheOrderDoesNotDependOnTheRun:
+    def test_the_same_records_in_any_order_settle_the_same_way(self):
+        records = _statements(
+            ("Gin Core Team", 2018), ("Gin Core Team", 2019),
+            ("Manu Martinez-Almeida", 2014), ("The Go Authors", 2009),
+        )
+        shuffled = [records[2], records[0], records[3], records[1]]
+
+        assert (
+            [r["statement"] for r in _in_a_settled_order(records)]
+            == [r["statement"] for r in _in_a_settled_order(shuffled)]
+        )
+
+    def test_and_reversing_them_changes_nothing(self):
+        records = _statements(
+            ("A Person", 2001), ("B Person", 2002), ("A Person", 2003),
+        )
+
+        assert (
+            _in_a_settled_order(records)
+            == _in_a_settled_order(list(reversed(records)))
+        )
+
+    def test_the_file_is_not_what_decides(self):
+        """It cannot be: the same statement arrives against a different file
+        each run, so an order built on it moves with the run."""
+        records = _statements(("A Person", 2001), ("B Person", 2002))
+        moved = [dict(record, file="/tmp/somewhere/else.go") for record in records]
+
+        assert (
+            [r["statement"] for r in _in_a_settled_order(records)]
+            == [r["statement"] for r in _in_a_settled_order(moved)]
+        )
+
+
+class TestTheHolderWhoCoversMostComesFirst:
+    """Whoever is named across the most files is the one whose package this
+    is. Ordering on the statement alone is stable but puts a vendored
+    "Copyright 2009 The Go Authors" ahead of the people who wrote it."""
+
+    def test_the_dominant_holder_leads(self):
+        """The names are chosen so that coverage and the alphabet disagree.
+        With names where they agree, an ordering that ignores coverage
+        entirely still passes."""
+        records = _statements(
+            ("Alpha Authors", 2009),
+            ("Zed Core Team", 2018),
+            ("Zed Core Team", 2019),
+            ("Zed Core Team", 2020),
+        )
+
+        assert _in_a_settled_order(records)[0]["holder"] == "Zed Core Team"
+
+    def test_however_the_records_arrive(self):
+        records = _statements(
+            ("Zed Core Team", 2018),
+            ("Alpha Authors", 2009),
+            ("Zed Core Team", 2019),
+        )
+
+        assert _in_a_settled_order(list(reversed(records)))[0]["holder"] == (
+            "Zed Core Team"
+        )
+
+    def test_and_the_one_named_once_comes_last(self):
+        records = _statements(
+            ("Alpha Authors", 2009),
+            ("Zed Core Team", 2018),
+            ("Zed Core Team", 2019),
+        )
+
+        assert _in_a_settled_order(records)[-1]["holder"] == "Alpha Authors"
+
+    def test_a_tie_is_broken_by_name_then_statement(self):
+        records = _statements(("B Person", 2002), ("A Person", 2001))
+
+        settled = _in_a_settled_order(records)
+
+        assert [r["holder"] for r in settled] == ["A Person", "B Person"]
+
+
+class TestEveryPackageReadsTheSameWayTwice:
+    @pytest.mark.parametrize("package", sorted(
+        path.name for path in PACKAGES.iterdir()
+        if path.is_file() and path.suffix not in (".sh", ".txt", ".json")
+    ))
+    def test_it_does(self, package):
+        first = _record(PACKAGES / package)
+        second = _record(PACKAGES / package)
+
+        assert hashlib.md5(first.encode()).hexdigest() == (
+            hashlib.md5(second.encode()).hexdigest()
+        ), package
+
+
+class TestNothingIsLostToTheCap:
+    """The cap was applied to the records before they were deduplicated or
+    ordered, so a package with eleven statements dropped a different one each
+    run, and the list of authors was cut short with them."""
+
+    def test_every_holder_is_reported_however_many_there_are(self, tmp_path):
+        source = tmp_path / "pkg"
+        source.mkdir()
+        for index in range(15):
+            (source / f"file_{index:02d}.go").write_text(
+                f"// Copyright 20{index:02d} Person {index:02d}\npackage main\n"
+            )
+
+        metadata = PackageMetadata(name="x", package_type=PackageType.GO_MODULE)
+        from upmex.extractors.npm_extractor import NpmExtractor
+
+        NpmExtractor().find_and_detect_copyrights(
+            directory_path=str(source), merge_with_authors=True, metadata=metadata
+        )
+
+        assert len(metadata.authors) > 10, [a["name"] for a in metadata.authors]
+
+    def test_the_summary_is_still_bounded(self, tmp_path):
+        """It is a summary, so it may be cut. It just has to cut the same
+        statements every time."""
+        from upmex.extractors.base import MAX_COPYRIGHT_STATEMENTS
+        from upmex.extractors.npm_extractor import NpmExtractor
+
+        source = tmp_path / "pkg"
+        source.mkdir()
+        for index in range(15):
+            (source / f"file_{index:02d}.go").write_text(
+                f"// Copyright 20{index:02d} Person {index:02d}\npackage main\n"
+            )
+
+        summaries = set()
+        for _ in range(3):
+            metadata = PackageMetadata(name="x", package_type=PackageType.GO_MODULE)
+            summaries.add(NpmExtractor().find_and_detect_copyrights(
+                directory_path=str(source), merge_with_authors=True,
+                metadata=metadata,
+            ))
+
+        assert len(summaries) == 1, summaries
+        only = summaries.pop()
+        assert len(only.split(";")) <= MAX_COPYRIGHT_STATEMENTS


### PR DESCRIPTION
Closes #117.

Extracting the same package twice gave two different records. On `test-packages/gin-v1.10.0.zip`:

```
run 1  Copyright 2021 Gin Core Team; Copyright 2014 Manu Martinez-Almeida; ...
run 2  Copyright 2014 Manu Martinez-Almeida; Copyright 2021 Gin Core Team; ...
run 4  Copyright 2014 Manu Martinez-Almeida; Copyright 2022 Gin Core Team; ...
```

A different first author, a different set of statements, and in run 4 a different year. A record whose content depends on the run cannot be diffed against a previous release, compared in CI, or attested to.

## Cause

osslili extracts concurrently, so the order it returns evidence in changes every run. Four things leaned on that order:

- Copyright records were cut to the first ten **before** being deduplicated, so a package with eleven dropped a different one each run.
- Holders became authors in arrival order, so whoever arrived first was named the author. That list was cut at ten too.
- Licence and copyright evidence was deduplicated keeping **whichever arrived first**, so the fields published beside an identifier (`source`, `match_type`, `file`) moved even when the identifier did not.
- Gradle keywords were published straight out of a `set`, whose order depends on the hash seed.

## Fix

Everything is ordered before anything picks a survivor from it. Evidence from every scan result is flattened and ordered once, then deduplicated; the cut to ten happens after ordering and applies only to the joined summary; the author list is not cut at all.

Copyright records are ordered by how many years each holder claims, then by holder and statement.

**Not by the file.** That is the least stable field in the record: osslili reports each statement once and attaches whichever file's thread reached it first, so the same statement arrives against `gin_test.go` on one run and `utils_test.go` on the next.

**Not by the statement alone.** Stable, but it reads the package as belonging to whoever comes first alphabetically, which named a vendored `Copyright 2009 The Go Authors` as gin's author.

**Years rather than statements**, because a project writing `Copyright 2013-2023` makes one statement covering eleven years. Counting statements gave cobra's sole copyright line no weight at all. osslili expands a range, so the years are there to count.

It is a heuristic, it decides only the order, and every holder is reported either way. The better signal would be how many files name each holder, and that is not in the record: osslili reports each statement once however many files carry it.

## What the tests could not see

Three of them tested the thing they were named for and could not have failed:

- The licence test compared **identifiers**, while the part that moved was the fields around them.
- The keyword test compared three calls **in one process**, and a set's order is fixed within a process and only moves between them.
- The regression test **sorted the licences** before comparing, hiding exactly the change it existed to catch.

And the whole-record test extracted twice inside one pytest process, so it shared one hash seed. Replacing the author merge with a loop over a set of holders passed all 700 tests and still gave gin four different author orders across four seeds. Two packages are now extracted in separate processes under four seeds and compared whole.

## Also settled

The older osslili output format deduplicated in arrival order, the fix having been applied only to the current one. The Perl extractor picked its package directory out of an unordered `os.listdir`.

## Verification

710 tests pass, 1 skipped. Lint clean.

Every package under `test-packages/` extracted under three hash seeds: one record each, no exceptions.

Compared against main: 17 of 18 byte-identical. The one that differs is gin, the package that was broken, where the first author settles on Gin Core Team.

Twenty mutations across the ordering, the cut, the dedupe and the walks, all caught.